### PR TITLE
add Hindcast data PM predictability possible

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -63,7 +63,8 @@ New Features
   :py:meth:`~climpred.classes.HindcastEnsemble.add_uninitialized`,
   :py:meth:`~climpred.classes.PerfectModelEnsemble.add_control` to ensure that the
   verification data calendars match that of the initialized ensemble.
-  (:pr:`452`) `Riley X. Brady`_
+  (:issue:`300`, :pr:`452`, :issue:`422`,:pr:`462`)
+  `Riley X. Brady`_ and `Aaron Spring`_.
 - Implement new metrics which have been ported over from
   https://github.com/csiro-dcfp/doppyo/ to ``xskillscore`` by Dougie Squire.
   (:pr:`439`, :pr:`456`) `Aaron Spring`_

--- a/climpred/tests/test_perfectModelEnsemble_class.py
+++ b/climpred/tests/test_perfectModelEnsemble_class.py
@@ -1,7 +1,7 @@
 import pytest
 import xarray as xr
 
-from climpred import PerfectModelEnsemble
+from climpred import HindcastEnsemble, PerfectModelEnsemble
 
 
 def test_perfectModelEnsemble_init(PM_ds_initialized_1d):
@@ -175,3 +175,54 @@ def test_calendar_matching_control(PM_da_initialized_1d, PM_ds_control_1d):
     with pytest.raises(ValueError) as excinfo:
         pm = pm.add_control(PM_ds_control_1d)
     assert "does not match" in str(excinfo.value)
+
+
+def test_HindcastEnsemble_as_PerfectModelEnsemble(
+    hind_ds_initialized_1d, reconstruction_ds_1d
+):
+    """Test that initialized dataset for HindcastEnsemble can also be used for
+        PerfectModelEnsemble."""
+    v = "SST"
+    hind_ds_initialized_1d["init"] = xr.cftime_range(
+        start="1954", periods=hind_ds_initialized_1d.init.size, freq="YS"
+    )
+    hind_ds_initialized_1d["lead"].attrs["units"] = "years"
+    reconstruction_ds_1d["time"] = xr.cftime_range(
+        start="1948", periods=reconstruction_ds_1d["time"].size, freq="YS"
+    )
+    hindcast = HindcastEnsemble(hind_ds_initialized_1d)
+    hindcast = hindcast.add_observations(reconstruction_ds_1d)
+    assert (
+        not hindcast.verify(
+            metric="acc", comparison="e2o", dim="init", alignment="same_verif"
+        )[v]
+        .isnull()
+        .any()
+    )
+
+    # try PerfectModelEnsemble predictability
+    pm = PerfectModelEnsemble(hind_ds_initialized_1d)
+    # add fake control, remove after #461
+    pm = pm.add_control(
+        hind_ds_initialized_1d.isel(member=0, lead=0, drop=True).rename(
+            {"init": "time"}
+        )
+    )
+    assert (
+        not pm.verify(metric="acc", comparison="m2e", dim=["member", "init"])[v]
+        .isnull()
+        .any()
+    )
+
+    # generate_uninitialized
+    pm = pm.generate_uninitialized()
+    assert (
+        not pm.verify(
+            metric="acc",
+            comparison="m2e",
+            dim=["member", "init"],
+            reference=["uninitialized"],
+        )[v]
+        .isnull()
+        .any()
+    )


### PR DESCRIPTION
# Description

 - already solved by @bradyrx 
- test shows how HindcastEnsemble and PerfectModelEnsemble predictability can be assessed for the same initialized dataset

Closes #422 

## To-Do List

Feel free to add a checklist of steps to be performed while you are working through creating this PR.

## Checklist (while developing)

-   [x]  Tests added for `pytest`, if necessary.
-   [x]  CHANGELOG is updated with reference to this PR.

## Pre-Merge Checklist (final steps)

-   [ ]  I have rebased onto master or develop (wherever I am merging) and dealt with any conflicts.
-   [ ]  I have squashed commits to a reasonable amount, and force-pushed the squashed commits.