### PR TITLE
try pull_request_target

### DIFF
--- a/.github/workflows/climpred_testing.yml
+++ b/.github/workflows/climpred_testing.yml
@@ -1,6 +1,6 @@
 name: climpred testing
 
-on: [push]
+on: [push, pull_request_target]
 
 jobs:
   test:  # Runs testing suite on various python versions.


### PR DESCRIPTION
Tries adding `pull_request_target` to github actions to give permission to forked PRs.

to do:
1. See how this affects the tests launched here on the main branch
2. Open PR on forked branch and see if tests run there
3. Ensure that tests aren't run against master (like previously with `pull_request`). Can purposefully break a test on the branch and see.
4. Push something else to the branch and make sure tests re-run.