### PR TITLE
fix labeling of hindcast initialized

### DIFF
--- a/climpred/classes.py
+++ b/climpred/classes.py
@@ -1129,7 +1129,7 @@ class HindcastEnsemble(PredictionEnsemble):
             if "time" in result.dims:
                 result = result.rename({"time": "init"})
             # Add dimension/coordinate for different references.
-            result = result.assign_coords(skill=["init"] + reference)
+            result = result.assign_coords(skill=["initialized"] + reference)
             return result.squeeze()
 
         has_dataset(

--- a/docs/source/alignment.ipynb
+++ b/docs/source/alignment.ipynb
@@ -168,7 +168,7 @@
     "\n",
     "for alignment, color in zip(['same_inits', 'same_verifs', 'maximize'], COLORS):\n",
     "    result = hindcast_dt.verify(metric='acc', reference='persistence', comparison='e2o', dim='init', alignment=alignment)\n",
-    "    result.sel(skill='init').SST.plot(label=alignment, color=color)\n",
+    "    result.sel(skill='initialized').SST.plot(label=alignment, color=color)\n",
     "    result.sel(skill='persistence').SST.plot(linestyle='--', color=color, lw=3)\n",
     "\n",
     "axs.set(ylabel='anomaly\\ncorrelation coefficient',\n",

--- a/docs/source/examples/decadal/Significance.ipynb
+++ b/docs/source/examples/decadal/Significance.ipynb
@@ -779,7 +779,7 @@
    "outputs": [],
    "source": [
     "# orientation is negative since lower scores are better for MAE\n",
-    "walk = sign_test(skill.sel(skill='init'), skill.sel(skill='uninitialized'), time_dim='init', orientation='negative', alpha=sig)"
+    "walk = sign_test(skill.sel(skill='initialized'), skill.sel(skill='uninitialized'), time_dim='init', orientation='negative', alpha=sig)"
    ]
   },
   {

--- a/docs/source/examples/decadal/diagnose-potential-predictability.ipynb
+++ b/docs/source/examples/decadal/diagnose-potential-predictability.ipynb
@@ -329,7 +329,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bootstrap_skill = pm.bootstrap(metric='rmse', comparison='m2e', dim=['init', 'member'], iterations=10)"
+    "bootstrap_skill = pm.bootstrap(metric='rmse', comparison='m2e', dim=['init', 'member'], iterations=10, reference='initialized')"
    ]
   },
   {
@@ -343,9 +343,9 @@
    },
    "outputs": [],
    "source": [
-    "init_skill = bootstrap_skill.sel(results='skill',kind='initialized')\n",
+    "init_skill = bootstrap_skill.sel(results='verify skill',skill='initialized')\n",
     "# p value: probability that random uninitialized forecasts perform better than initialized\n",
-    "p = bootstrap_skill.sel(results='p',kind='uninitialized')"
+    "p = bootstrap_skill.sel(results='p',skill='uninitialized')"
    ]
   },
   {

--- a/docs/source/prediction-ensemble-object.ipynb
+++ b/docs/source/prediction-ensemble-object.ipynb
@@ -7193,7 +7193,7 @@
     "    handles = []\n",
     "    result = hindcast_detrended.verify(metric=metric, comparison='e2o', dim='init',\n",
     "                                 alignment='same_verif',reference='persistence')\n",
-    "    p1, = result.sel(skill='init').SST.plot(ax=ax, \n",
+    "    p1, = result.sel(skill='initialized').SST.plot(ax=ax, \n",
     "                                       marker='o', \n",
     "                                       color=color,\n",
     "                                       label='initialized forecast model',\n",

--- a/docs/source/quick-start.ipynb
+++ b/docs/source/quick-start.ipynb
@@ -1211,7 +1211,7 @@
    ],
    "source": [
     "result = hindcast.verify(metric='acc', comparison='e2o', dim='init', alignment='same_verif', reference='persistence')\n",
-    "skill = result.sel(skill='init')\n",
+    "skill = result.sel(skill='initialized')\n",
     "persistence = result.sel(skill='persistence')\n",
     "print(skill)"
    ]
@@ -1269,7 +1269,7 @@
    "outputs": [],
    "source": [
     "result = hindcast.verify(metric='rmse', comparison='e2o', dim='init', alignment='same_verif', reference='persistence')\n",
-    "skill = result.sel(skill='init')\n",
+    "skill = result.sel(skill='initialized')\n",
     "persistence = result.sel(skill='persistence')"
    ]
   },


### PR DESCRIPTION
# Description

Fixes small bug for `HindcastEnsemble.verify()` to label `init` now `initialized`.
