### PR TITLE
allow multiple types for dim

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,18 @@
 What's New
 ==========
 
+climpred v2.1.x (2021-0x-xx)
+============================
+
+New Features
+------------
+
+Bug fixes
+---------
+- `~climpred.classes.PredictionEnsemble.verify` and
+  `~climpred.classes.PredictionEnsemble.bootstrap` accept ``dim`` as ``list``, ``set``,
+   ``tuple`` or ``str`` (:issue:`519`, pr:`558`) `Aaron Spring`_.
+
 
 climpred v2.1.2 (2021-01-22)
 ============================

--- a/climpred/prediction.py
+++ b/climpred/prediction.py
@@ -99,12 +99,16 @@ def _rename_dim(dim, forecast, verif):
     return dim
 
 
-def _sanitize_str_to_list(dim):
-    """Make dim to list if string, pass if None else raise ValueError."""
+def _sanitize_to_list(dim):
+    """Make dim to list if string, tuple or set, pass if None else raise ValueError."""
     if isinstance(dim, str):
         dim = [dim]
+    elif isinstance(dim, set):
+        dim = list(dim)
+    elif isinstance(dim, tuple):
+        dim = list(dim)
     elif isinstance(dim, list) or dim is None:
-        dim = dim
+        pass
     else:
         raise ValueError(
             f"Expected `dim` as `str`, `list` or None, found {dim} as type {type(dim)}."
@@ -127,7 +131,7 @@ def _get_metric_comparison_dim(initialized, metric, comparison, dim, kind):
         comparison (Comparison): comparison class.
         dim (list of str or str): corrected dimension to apply metric to.
     """
-    dim = _sanitize_str_to_list(dim)
+    dim = _sanitize_to_list(dim)
 
     # check kind allowed
     is_in_list(kind, ["hindcast", "PM"], "kind")

--- a/climpred/tests/conftest.py
+++ b/climpred/tests/conftest.py
@@ -267,9 +267,6 @@ def observations_da_1d(observations_ds_1d):
 @pytest.fixture()
 def hindcast_recon_3d(hind_ds_initialized_3d, reconstruction_ds_3d):
     """HindcastEnsemble initialized with `initialized`, `reconstruction`(`recon`)."""
-    # fix to align coords
-    for c in ["TLAT", "TLONG", "TAREA"]:
-        reconstruction_ds_3d[c] = hind_ds_initialized_3d[c]
     hindcast = HindcastEnsemble(hind_ds_initialized_3d)
     hindcast = hindcast.add_observations(reconstruction_ds_3d)
     hindcast = hindcast - hindcast.sel(time=slice("1964", "2014")).mean("time").sel(

--- a/climpred/tests/test_HindcastEnsemble_class.py
+++ b/climpred/tests/test_HindcastEnsemble_class.py
@@ -99,15 +99,17 @@ def test_inplace(
     assert hindcast != summed
 
 
+@pytest.mark.parametrize("call", ["verify", "bootstrap"])
 @pytest.mark.parametrize(
     "dim",
     [set(["init"]), list(["init"]), tuple(["init"]), "init"],
     ids=["set", "list", "tuple", "str"],
 )
-def test_verify_dim_input_type(hindcast_hist_obs_1d, dim):
+def test_dim_input_type(hindcast_hist_obs_1d, dim, call):
     """Test verify for different dim types."""
-    hindcast_hist_obs_1d.verify(
-        metric="rmse", comparison="e2o", dim=dim, alignment="same_verifs"
+    kw = dict(iterations=2) if call == "bootstrap" else {}
+    getattr(hindcast_hist_obs_1d, call)(
+        metric="rmse", comparison="e2o", dim=dim, alignment="same_verifs", **kw
     )
 
 

--- a/climpred/tests/test_HindcastEnsemble_class.py
+++ b/climpred/tests/test_HindcastEnsemble_class.py
@@ -103,6 +103,18 @@ def test_inplace(
     assert hindcast != summed
 
 
+@pytest.mark.parametrize(
+    "dim",
+    [set(["init"]), list(["init"]), tuple(["init"]), "init"],
+    ids=["set", "list", "tuple", "str"],
+)
+def test_verify_dim_input_type(hindcast_hist_obs_1d, dim):
+    """Test verify for different dim types."""
+    hindcast_hist_obs_1d.verify(
+        metric="rmse", comparison="e2o", dim=dim, alignment="same_verifs"
+    )
+
+
 @pytest.mark.parametrize("alignment", ["same_inits", "same_verifs", "maximize"])
 def test_mean_remove_bias(hindcast_hist_obs_1d, alignment):
     """Test remove mean bias, ensure than skill doesnt degrade and keeps attrs."""

--- a/climpred/tests/test_HindcastEnsemble_class.py
+++ b/climpred/tests/test_HindcastEnsemble_class.py
@@ -106,22 +106,10 @@ def test_inplace(
     ids=["set", "list", "tuple", "str"],
 )
 def test_dim_input_type(hindcast_hist_obs_1d, dim, call):
-    """Test verify for different dim types."""
+    """Test verify and bootstrap for different dim types."""
     kw = dict(iterations=2) if call == "bootstrap" else {}
-    getattr(hindcast_hist_obs_1d, call)(
+    assert getattr(hindcast_hist_obs_1d, call)(
         metric="rmse", comparison="e2o", dim=dim, alignment="same_verifs", **kw
-    )
-
-
-@pytest.mark.parametrize(
-    "dim",
-    [set(["init"]), list(["init"]), tuple(["init"]), "init"],
-    ids=["set", "list", "tuple", "str"],
-)
-def test_bootstrap_dim_input_type(hindcast_hist_obs_1d, dim):
-    """Test bootstrap for different dim types."""
-    hindcast_hist_obs_1d.bootstrap(
-        iterations=2, metric="rmse", comparison="e2o", dim=dim, alignment="same_verifs"
     )
 
 

--- a/climpred/tests/test_HindcastEnsemble_class.py
+++ b/climpred/tests/test_HindcastEnsemble_class.py
@@ -59,27 +59,25 @@ def test_isel_xarray_func(hindcast_hist_obs_1d):
     assert hindcast.get_observations().time.size == 5
 
 
-def test_get_initialized(hind_ds_initialized_1d):
+def test_get_initialized(hindcast_hist_obs_1d):
     """Test whether get_initialized method works."""
-    hindcast = HindcastEnsemble(hind_ds_initialized_1d)
-    init = hindcast.get_initialized()
-    assert init == hindcast._datasets["initialized"]
+    assert hindcast_hist_obs_1d.get_initialized().identical(
+        hindcast_hist_obs_1d._datasets["initialized"]
+    )
 
 
-def test_get_uninitialized(hind_ds_initialized_1d, hist_ds_uninitialized_1d):
+def test_get_uninitialized(hindcast_hist_obs_1d):
     """Test whether get_uninitialized method works."""
-    hindcast = HindcastEnsemble(hind_ds_initialized_1d)
-    hindcast = hindcast.add_uninitialized(hist_ds_uninitialized_1d)
-    uninit = hindcast.get_uninitialized()
-    assert uninit == hindcast._datasets["uninitialized"]
+    assert hindcast_hist_obs_1d.get_uninitialized().identical(
+        hindcast_hist_obs_1d._datasets["uninitialized"]
+    )
 
 
-def test_get_observations(hind_ds_initialized_1d, reconstruction_ds_1d):
+def test_get_observations(hindcast_hist_obs_1d):
     """Tests whether get_observations method works."""
-    hindcast = HindcastEnsemble(hind_ds_initialized_1d)
-    hindcast = hindcast.add_observations(reconstruction_ds_1d)
-    obs = hindcast.get_observations()
-    assert obs == hindcast._datasets["observations"]
+    assert hindcast_hist_obs_1d.get_observations().identical(
+        hindcast_hist_obs_1d._datasets["observations"]
+    )
 
 
 def test_inplace(
@@ -110,6 +108,18 @@ def test_verify_dim_input_type(hindcast_hist_obs_1d, dim):
     """Test verify for different dim types."""
     hindcast_hist_obs_1d.verify(
         metric="rmse", comparison="e2o", dim=dim, alignment="same_verifs"
+    )
+
+
+@pytest.mark.parametrize(
+    "dim",
+    [set(["init"]), list(["init"]), tuple(["init"]), "init"],
+    ids=["set", "list", "tuple", "str"],
+)
+def test_bootstrap_dim_input_type(hindcast_hist_obs_1d, dim):
+    """Test bootstrap for different dim types."""
+    hindcast_hist_obs_1d.bootstrap(
+        iterations=2, metric="rmse", comparison="e2o", dim=dim, alignment="same_verifs"
     )
 
 


### PR DESCRIPTION
# Description

allow multiple types for dim: str, list of str, tuple of str, set of str, user is encouraged to use str or list of str as in docstrings mentioned already before

also rm coords fix in conftest, which is not needed after #543 which changed coords in climpred-data

Closes #519

## To-Do List

Feel free to add a checklist of steps to be performed while you are working through creating this PR.

## Type of change

Please delete options that are not relevant.

-   [x]  Bug fix (non-breaking change which fixes an issue)
-   [ ]  New feature (non-breaking change which adds functionality)
-   [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ]  This change requires a documentation update
-   [ ]  Performance (if you touched existing code run `asv` to detect performance changes)
-   [x]  Refactoring

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. This could point to a cell in the updated notebooks. Or a snippet of code with accompanying figures here.

## Checklist (while developing)

-   [x]  I have added docstrings to all new functions.
-   [x]  I have commented my code, particularly in hard-to-understand areas
-   [x]  Tests added for `pytest`, if necessary.
-   [x]  I have updated the sphinx documentation, if necessary.
-   [x]  Any new functions are added to the API. (See contribution guide)
-   [x]  CHANGELOG is updated with reference to this PR.

## Pre-Merge Checklist (final steps)

-   [ ]  I have rebased onto master or develop (wherever I am merging) and dealt with any conflicts.
-   [ ]  I have squashed commits to a reasonable amount, and force-pushed the squashed commits.

## References

Please add any references to manuscripts, textbooks, etc.
