### PR TITLE
Drop py 3.6

### DIFF
--- a/.github/workflows/climpred_installs.yml
+++ b/.github/workflows/climpred_installs.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.8
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/climpred_testing.yml
+++ b/.github/workflows/climpred_testing.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.6.0
@@ -97,7 +97,7 @@ jobs:
           channels: conda-forge
           mamba-version: '*'
           activate-environment: climpred-docs-notebooks
-          python-version: 3.6
+          python-version: 3.8
       - name: Set up conda environment
         run: |
           mamba env update -f ci/requirements/docs_notebooks.yml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,6 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.8
       - name: Lint via pre-commit checks
         uses: pre-commit/action@v2.0.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,7 @@ Internals/Minor Fixes
   testing suite on every single commit. (:pr:`560`) `Aaron Spring`_.
 - `~climpred.classes.PerfectModelEnsemble.verify` does not add climpred
   attributes by default anymore. (:pr:`560`) `Aaron Spring`_.
+- Drop python=3.6 support. (:pr:`573`) `Aaron Spring`_.
 
 climpred v2.1.2 (2021-01-22)
 ============================

--- a/ci/requirements/climpred-dev.yml
+++ b/ci/requirements/climpred-dev.yml
@@ -2,6 +2,7 @@ name: climpred-dev
 channels:
   - conda-forge
 dependencies:
+  - python>=3.7
   # Documentation
   - nbsphinx
   - nbstripout

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -2,7 +2,7 @@ name: climpred-docs
 channels:
   - conda-forge
 dependencies:
-  - python=3.6
+  - python=3.8
   - bottleneck
   - cartopy>=0.18.0
   - esmtools>=1.1.3

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -2,7 +2,7 @@ name: climpred-docs
 channels:
   - conda-forge
 dependencies:
-  - python=3.8
+  - python>=3.7
   - bottleneck
   - cartopy>=0.18.0
   - esmtools>=1.1.3

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -2,7 +2,7 @@ name: climpred-docs
 channels:
   - conda-forge
 dependencies:
-  - python>=3.7
+  - python=3.8
   - bottleneck
   - cartopy>=0.18.0
   - esmtools>=1.1.3

--- a/ci/requirements/docs_notebooks.yml
+++ b/ci/requirements/docs_notebooks.yml
@@ -2,6 +2,7 @@ name: climpred-docs-notebooks
 channels:
   - conda-forge
 dependencies:
+  - python>=3.7
   - xesmf
   - esmpy
   - bottleneck

--- a/ci/requirements/minimum-tests.yml
+++ b/ci/requirements/minimum-tests.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
   - numba/label/dev # Temporary fix to get Numba on Python 3.9
 dependencies:
+  - python>=3.7
   - cftime>=1.1.2
   - coveralls
   - dask

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ CLASSIFIERS = [
     "Operating System :: OS Independent",
     "Intended Audience :: Science/Research",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
 ]
@@ -28,7 +27,7 @@ setup(
     maintainer_email="riley.brady@colorado.edu",
     description="Verification of weather and climate forecasts." + " prediction.",
     install_requires=install_requires,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     license="MIT",
     long_description=long_description,
     classifiers=CLASSIFIERS,


### PR DESCRIPTION
drop py 3.6 support as xarray and numpy did. Climpred likely still works for py36 but py37 and above is encouraged and py36 related bugs will likely not be fixed