### PR TITLE
speed up tests

### DIFF
--- a/.github/workflows/climpred_testing.yml
+++ b/.github/workflows/climpred_testing.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Cache datasets  # pytest-xdist fails otherwise
         run: python -c "import climpred; climpred.tutorial._cache_all()"
       - name: Run tests
-        run: pytest -n 4 --durations=20--cov=climpred --cov-report=xml --verbose
+        run: pytest -n 4 --durations=20 --cov=climpred --cov-report=xml --verbose
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v1.0.7
         with:

--- a/.github/workflows/climpred_testing.yml
+++ b/.github/workflows/climpred_testing.yml
@@ -36,7 +36,7 @@ jobs:
         run: conda list
       - name: Run tests
         run: |
-          pytest -n 4 --dist loadscope --cov=climpred --cov-report=xml --verbose
+          pytest -n 4 --looponfail --cov=climpred --cov-report=xml --verbose
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v1.0.7
         with:

--- a/.github/workflows/climpred_testing.yml
+++ b/.github/workflows/climpred_testing.yml
@@ -36,7 +36,7 @@ jobs:
         run: conda list
       - name: Run tests
         run: |
-          pytest -n 4 --dist loadfile --cov=climpred --cov-report=xml --verbose
+          pytest -n 4 --dist loadscope --cov=climpred --cov-report=xml --verbose
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v1.0.7
         with:

--- a/.github/workflows/climpred_testing.yml
+++ b/.github/workflows/climpred_testing.yml
@@ -36,7 +36,7 @@ jobs:
         run: conda list
       - name: Run tests
         run: |
-          pytest -n 4 --looponfail --cov=climpred --cov-report=xml --verbose
+          pytest --cov=climpred --cov-report=xml --verbose
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v1.0.7
         with:

--- a/.github/workflows/climpred_testing.yml
+++ b/.github/workflows/climpred_testing.yml
@@ -36,7 +36,7 @@ jobs:
         run: conda list
       - name: Run tests
         run: |
-          pytest --cov=climpred --cov-report=xml --verbose
+          pytest -n 4 --cov=climpred --cov-report=xml --verbose
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v1.0.7
         with:

--- a/.github/workflows/climpred_testing.yml
+++ b/.github/workflows/climpred_testing.yml
@@ -36,7 +36,7 @@ jobs:
         run: conda list
       - name: Run tests
         run: |
-          pytest --cov=climpred --cov-report=xml --verbose
+          pytest -n 2 --cov=climpred --cov-report=xml --verbose
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v1.0.7
         with:

--- a/.github/workflows/climpred_testing.yml
+++ b/.github/workflows/climpred_testing.yml
@@ -36,6 +36,7 @@ jobs:
         run: conda list
       - name: Run tests
         run: |
+          python "import climpred; climpred.tutorial._cache_all()"
           if [[ ${{ matrix.python-version }} == 3.7 ]] ; then
             pytest --cov=climpred --cov-report=xml --verbose
           else

--- a/.github/workflows/climpred_testing.yml
+++ b/.github/workflows/climpred_testing.yml
@@ -36,7 +36,7 @@ jobs:
         run: conda list
       - name: Run tests
         run: |
-          pytest -n 2 --cov=climpred --cov-report=xml --verbose
+          pytest --cov=climpred --cov-report=xml --verbose
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v1.0.7
         with:

--- a/.github/workflows/climpred_testing.yml
+++ b/.github/workflows/climpred_testing.yml
@@ -34,10 +34,10 @@ jobs:
         run: conda info
       - name: Conda list
         run: conda list
+      - name: Cache datasets  # pytest-xdist fails otherwise
+        run: python -c "import climpred; climpred.tutorial._cache_all()"
       - name: Run tests
-        run: |
-          python -c "import climpred; climpred.tutorial._cache_all()"
-          pytest -n 4 --cov=climpred --cov-report=xml --verbose
+        run: pytest -n 4 --cov=climpred --cov-report=xml --verbose
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v1.0.7
         with:

--- a/.github/workflows/climpred_testing.yml
+++ b/.github/workflows/climpred_testing.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Cache datasets  # pytest-xdist fails otherwise
         run: python -c "import climpred; climpred.tutorial._cache_all()"
       - name: Run tests
-        run: pytest -n 4 --durations=20 --cov=climpred --cov-report=xml --verbose
+        run: pytest -n 4 --durations=20 --cov=climpred --cov-report=xml
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v1.0.7
         with:

--- a/.github/workflows/climpred_testing.yml
+++ b/.github/workflows/climpred_testing.yml
@@ -36,7 +36,7 @@ jobs:
         run: conda list
       - name: Run tests
         run: |
-          pytest -n 4 --cov=climpred --cov-report=xml --verbose
+          pytest -n 4 --dist loadfile --cov=climpred --cov-report=xml --verbose
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v1.0.7
         with:

--- a/.github/workflows/climpred_testing.yml
+++ b/.github/workflows/climpred_testing.yml
@@ -36,7 +36,11 @@ jobs:
         run: conda list
       - name: Run tests
         run: |
-          pytest -n 4 --cov=climpred --cov-report=xml --verbose
+          if [[ ${{ matrix.python-version }} == 3.7 ]] ; then
+            pytest --cov=climpred --cov-report=xml --verbose
+          else
+            pytest -n 4 --cov=climpred --cov-report=xml --verbose
+          fi
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v1.0.7
         with:

--- a/.github/workflows/climpred_testing.yml
+++ b/.github/workflows/climpred_testing.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Cache datasets  # pytest-xdist fails otherwise
         run: python -c "import climpred; climpred.tutorial._cache_all()"
       - name: Run tests
-        run: pytest -n 4 --cov=climpred --cov-report=xml --verbose
+        run: pytest -n 4 --durations=20--cov=climpred --cov-report=xml --verbose
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v1.0.7
         with:

--- a/.github/workflows/climpred_testing.yml
+++ b/.github/workflows/climpred_testing.yml
@@ -36,12 +36,8 @@ jobs:
         run: conda list
       - name: Run tests
         run: |
-          python "import climpred; climpred.tutorial._cache_all()"
-          if [[ ${{ matrix.python-version }} == 3.7 ]] ; then
-            pytest --cov=climpred --cov-report=xml --verbose
-          else
-            pytest -n 4 --cov=climpred --cov-report=xml --verbose
-          fi
+          python -c "import climpred; climpred.tutorial._cache_all()"
+          pytest -n 4 --cov=climpred --cov-report=xml --verbose
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v1.0.7
         with:

--- a/ci/requirements/climpred-dev.yml
+++ b/ci/requirements/climpred-dev.yml
@@ -1,6 +1,7 @@
 name: climpred-dev
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
   - python>=3.7
   # Documentation
@@ -52,7 +53,7 @@ dependencies:
   - esmtools>=1.1.3
   - xskillscore>=0.0.18
   # Visualization
-  - matplotlib
+  - matplotlib-base
   - nc-time-axis
   - pip
   - pip:

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -1,13 +1,14 @@
 name: climpred-docs
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
   - python=3.8
   - bottleneck
   - cartopy>=0.18.0
   - importlib_metadata
   - jupyterlab
-  - matplotlib
+  - matplotlib-base
   - nbsphinx
   - nc-time-axis
   - netcdf4

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -16,7 +16,7 @@ dependencies:
   - sphinx-copybutton
   - toolz
   - xarray>=0.16.1
-  - xskillscore>=0.0.19
+  - xskillscore>=0.0.18
   - pip
   - pip:
     # Install latest version of climpred.

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -4,24 +4,19 @@ channels:
   - nodefaults
 dependencies:
   - python=3.8
-  - bottleneck
-  - cartopy>=0.18.0
   - importlib_metadata
-  - jupyterlab
   - matplotlib-base
   - nbsphinx
   - nc-time-axis
   - netcdf4
-  - numpy
-  - pandas
   - pygments==2.6.1
   - sphinx
   - sphinxcontrib-napoleon
   - sphinx_rtd_theme
   - sphinx-copybutton
   - toolz
-  - tqdm
   - xarray>=0.16.1
+  - xskillscore>=0.0.19
   - pip
   - pip:
     # Install latest version of climpred.

--- a/ci/requirements/docs_notebooks.yml
+++ b/ci/requirements/docs_notebooks.yml
@@ -1,6 +1,7 @@
 name: climpred-docs-notebooks
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
   - python>=3.7
   - xesmf
@@ -8,7 +9,7 @@ dependencies:
   - bottleneck
   - importlib_metadata
   - jupyterlab
-  - matplotlib
+  - matplotlib-base
   - nbsphinx
   - nbstripout
   - nc-time-axis

--- a/ci/requirements/minimum-tests.yml
+++ b/ci/requirements/minimum-tests.yml
@@ -2,6 +2,7 @@ name: climpred-minimum-tests
 channels:
   - conda-forge
   - numba/label/dev # Temporary fix to get Numba on Python 3.9
+  - nodefaults
 dependencies:
   - python>=3.7
   - cftime>=1.1.2
@@ -10,7 +11,7 @@ dependencies:
   - eofs
   - esmpy=*=mpi*  # Ensures MPI works with version of esmpy.
   - ipython
-  - matplotlib
+  - matplotlib-base
   - nc-time-axis
   - netcdf4
   - pip

--- a/ci/requirements/minimum-tests.yml
+++ b/ci/requirements/minimum-tests.yml
@@ -16,6 +16,7 @@ dependencies:
   - pip
   - pytest
   - pytest-cov
+  - pytest-xdist
   - scipy
   - xarray>=0.16.1
   - xesmf

--- a/climpred/tests/test_HindcastEnsemble_class.py
+++ b/climpred/tests/test_HindcastEnsemble_class.py
@@ -108,7 +108,7 @@ def test_inplace(
 def test_dim_input_type(hindcast_hist_obs_1d, dim, call):
     """Test verify and bootstrap for different dim types."""
     kw = dict(iterations=2) if call == "bootstrap" else {}
-    assert getattr(hindcast_hist_obs_1d, call)(
+    assert getattr(hindcast_hist_obs_1d.isel(lead=range(3)), call)(
         metric="rmse", comparison="e2o", dim=dim, alignment="same_verifs", **kw
     )
 
@@ -120,7 +120,7 @@ def test_mean_remove_bias(hindcast_hist_obs_1d, alignment):
     metric = "rmse"
     dim = "init"
     comparison = "e2o"
-    hindcast = hindcast_hist_obs_1d
+    hindcast = hindcast_hist_obs_1d.isel(lead=range(3))
     hindcast._datasets["initialized"].attrs["test"] = "test"
     hindcast._datasets["initialized"]["SST"].attrs["units"] = "test_unit"
     verify_kwargs = dict(
@@ -228,7 +228,7 @@ def test_calendar_matching_uninitialized(
 @pytest.mark.parametrize("metric", ["mse", "crps"])
 def test_verify_reference_same_dims(hindcast_hist_obs_1d, metric):
     """Test that verify returns the same dimensionality regardless of reference."""
-    hindcast = hindcast_hist_obs_1d
+    hindcast = hindcast_hist_obs_1d.isel(lead=range(3), init=range(10))
     if metric == "mse":
         comparison = "e2o"
         dim = "init"

--- a/climpred/tests/test_HindcastEnsemble_class.py
+++ b/climpred/tests/test_HindcastEnsemble_class.py
@@ -197,34 +197,6 @@ def test_verify_fails_expected_metric_kwargs(hindcast_hist_obs_1d):
         )
 
 
-def test_verify_m2o_reference(hindcast_hist_obs_1d):
-    """Test that m2o comparison in references work."""
-    hindcast = hindcast_hist_obs_1d
-    # determinstic
-    hindcast.verify(
-        metric="mse",
-        comparison="m2o",
-        dim="init",
-        alignment="same_verif",
-        reference="uninitialized",
-    )
-    hindcast.verify(
-        metric="mse",
-        comparison="m2o",
-        dim="init",
-        alignment="same_verif",
-        reference="persistence",
-    )
-    # probabilistic
-    hindcast.verify(
-        metric="crps",
-        comparison="m2o",
-        reference="uninitialized",
-        dim="member",
-        alignment="same_verif",
-    )
-
-
 def test_calendar_matching_observations(hind_ds_initialized_1d, reconstruction_ds_1d):
     """Tests that error is thrown if calendars mismatch when adding observations."""
     hindcast = HindcastEnsemble(hind_ds_initialized_1d)

--- a/climpred/tests/test_PerfectModelEnsemble_class.py
+++ b/climpred/tests/test_PerfectModelEnsemble_class.py
@@ -22,14 +22,12 @@ comparison_dim_PM = [
 ]
 
 references = [
-    [],
     "uninitialized",
     "persistence",
     "climatology",
     ["climatology", "uninitialized", "persistence"],
 ]
 references_ids = [
-    "empty list",
     "uninitialized",
     "persistence",
     "climatology",
@@ -129,18 +127,7 @@ def test_verify_metric_kwargs(perfectModelEnsemble_initialized_control):
     )
 
 
-@pytest.mark.parametrize(
-    "reference",
-    [
-        "uninitialized",
-        ["uninitialized"],
-        "persistence",
-        None,
-        [],
-        "climatology",
-        ["uninitialized", "persistence", "climatology"],
-    ],
-)
+@pytest.mark.parametrize("reference", references, ids=references_ids)
 def test_verify_reference(perfectModelEnsemble_initialized_control, reference):
     """Test that verify works with references given."""
     pm = perfectModelEnsemble_initialized_control.generate_uninitialized()
@@ -371,7 +358,7 @@ def test_PerfectModel_verify_bootstrap_deterministic(
     """
     Checks that PerfectModel.verify() and PerfectModel.bootstrap() for deterministic metrics is not NaN.
     """
-    pm = perfectModelEnsemble_initialized_control.isel(lead=[0, 1, 2])
+    pm = perfectModelEnsemble_initialized_control.isel(lead=[0, 1], init=[0, 1, 2])
     if isinstance(reference, str):
         reference = [reference]
     if metric == "contingency":
@@ -439,7 +426,7 @@ def test_PerfectModel_verify_bootstrap_deterministic(
 def test_pvalue_from_bootstrapping(perfectModelEnsemble_initialized_control, metric):
     """Test that pvalue of initialized ensemble first lead is close to 0."""
     sig = 95
-    pm = perfectModelEnsemble_initialized_control.isel(lead=[0, 1, 2])
+    pm = perfectModelEnsemble_initialized_control.isel(lead=[0, 1])
     actual = (
         pm.bootstrap(
             metric=metric,

--- a/climpred/tests/test_PerfectModelEnsemble_class.py
+++ b/climpred/tests/test_PerfectModelEnsemble_class.py
@@ -358,7 +358,7 @@ def test_PerfectModel_verify_bootstrap_deterministic(
     """
     Checks that PerfectModel.verify() and PerfectModel.bootstrap() for deterministic metrics is not NaN.
     """
-    pm = perfectModelEnsemble_initialized_control.isel(lead=[0, 1], init=[0, 1, 2])
+    pm = perfectModelEnsemble_initialized_control.isel(lead=[0, 1, 2])
     if isinstance(reference, str):
         reference = [reference]
     if metric == "contingency":

--- a/climpred/tests/test_PerfectModelEnsemble_class.py
+++ b/climpred/tests/test_PerfectModelEnsemble_class.py
@@ -426,7 +426,7 @@ def test_PerfectModel_verify_bootstrap_deterministic(
 def test_pvalue_from_bootstrapping(perfectModelEnsemble_initialized_control, metric):
     """Test that pvalue of initialized ensemble first lead is close to 0."""
     sig = 95
-    pm = perfectModelEnsemble_initialized_control.isel(lead=[0, 1])
+    pm = perfectModelEnsemble_initialized_control.isel(lead=[0, 1, 2])
     actual = (
         pm.bootstrap(
             metric=metric,

--- a/climpred/tests/test_PerfectModelEnsemble_class.py
+++ b/climpred/tests/test_PerfectModelEnsemble_class.py
@@ -235,7 +235,7 @@ def test_HindcastEnsemble_as_PerfectModelEnsemble(hindcast_recon_1d_mm):
     PerfectModelEnsemble."""
     v = "SST"
     alignment = "maximize"
-    hindcast = hindcast_recon_1d_mm.isel(lead=[0, 1], init=slice(None, 10))
+    hindcast = hindcast_recon_1d_mm.isel(lead=[0, 1])
     assert (
         not hindcast.verify(
             metric="acc", comparison="e2o", dim="init", alignment=alignment

--- a/climpred/tests/test_PerfectModelEnsemble_class.py
+++ b/climpred/tests/test_PerfectModelEnsemble_class.py
@@ -235,7 +235,7 @@ def test_HindcastEnsemble_as_PerfectModelEnsemble(hindcast_recon_1d_mm):
     PerfectModelEnsemble."""
     v = "SST"
     alignment = "maximize"
-    hindcast = hindcast_recon_1d_mm
+    hindcast = hindcast_recon_1d_mm.isel(lead=[0, 1], init=slice(None, 10))
     assert (
         not hindcast.verify(
             metric="acc", comparison="e2o", dim="init", alignment=alignment
@@ -254,34 +254,13 @@ def test_HindcastEnsemble_as_PerfectModelEnsemble(hindcast_recon_1d_mm):
         .any()
     )
 
-    pm = pm.add_control(
-        init.isel(member=0, lead=0, drop=True)
-        .rename({"init": "time"})
-        .resample(time="1MS")
-        .interpolate("linear")
-    )
-
-    pm = pm.generate_uninitialized()
-    assert (
-        not pm.verify(
-            metric="acc",
-            comparison="m2e",
-            dim=["member", "init"],
-            reference=["uninitialized"],
-        )[v]
-        .isnull()
-        .any()
-    )
-
-    pm.bootstrap(iterations=2, metric="acc", comparison="m2e", dim=["member", "init"])
-
 
 def test_verify_no_need_for_control(PM_da_initialized_1d, PM_da_control_1d):
     """Tests that no error is thrown when no control present
     when calling verify(reference=['uninitialized'])."""
     v = "tos"
     comparison = "m2e"
-    pm = PerfectModelEnsemble(PM_da_initialized_1d).load()
+    pm = PerfectModelEnsemble(PM_da_initialized_1d).isel(lead=[0, 1, 2])
     # verify needs to control
     skill = pm.verify(metric="mse", comparison=comparison, dim="init")
     assert not skill[v].isnull().any()
@@ -323,6 +302,7 @@ def test_verify_no_need_for_control(PM_da_initialized_1d, PM_da_control_1d):
 def test_verify_reference_same_dims(perfectModelEnsemble_initialized_control):
     """Test that verify returns the same dimensionality regardless of reference."""
     pm = perfectModelEnsemble_initialized_control.generate_uninitialized()
+    pm = pm.isel(lead=[0, 1, 2], init=[0, 1, 2])
     metric = "mse"
     comparison = "m2e"
     dim = "init"
@@ -356,9 +336,10 @@ def test_PerfectModel_verify_bootstrap_deterministic(
     perfectModelEnsemble_initialized_control, comparison, metric, dim, reference
 ):
     """
-    Checks that PerfectModel.verify() and PerfectModel.bootstrap() for deterministic metrics is not NaN.
+    Checks that PerfectModel.verify() and PerfectModel.bootstrap() for
+    deterministic metrics is not NaN.
     """
-    pm = perfectModelEnsemble_initialized_control.isel(lead=[0, 1, 2])
+    pm = perfectModelEnsemble_initialized_control.isel(lead=[0, 1, 2], init=[0, 1, 2])
     if isinstance(reference, str):
         reference = [reference]
     if metric == "contingency":

--- a/climpred/tests/test_PerfectModelEnsemble_class.py
+++ b/climpred/tests/test_PerfectModelEnsemble_class.py
@@ -339,7 +339,7 @@ def test_PerfectModel_verify_bootstrap_deterministic(
     Checks that PerfectModel.verify() and PerfectModel.bootstrap() for
     deterministic metrics is not NaN.
     """
-    pm = perfectModelEnsemble_initialized_control.isel(lead=[0, 1, 2], init=[0, 1, 2])
+    pm = perfectModelEnsemble_initialized_control.isel(lead=[0, 1, 2], init=range(6))
     if isinstance(reference, str):
         reference = [reference]
     if metric == "contingency":

--- a/climpred/tests/test_bootstrap.py
+++ b/climpred/tests/test_bootstrap.py
@@ -55,7 +55,7 @@ def test_bootstrap_PM_lazy_results(
     perfectModelEnsemble_initialized_control, chunk, comparison, dim
 ):
     """Test bootstrap_perfect_model works lazily."""
-    pm = perfectModelEnsemble_initialized_control
+    pm = perfectModelEnsemble_initialized_control.isel(lead=range(3))
     if chunk:
         pm = pm.chunk({"lead": 2}).chunk({"time": -1})
     else:
@@ -76,7 +76,7 @@ def test_bootstrap_hindcast_lazy(
     chunk,
 ):
     """Test bootstrap_hindcast works lazily."""
-    he = hindcast_hist_obs_1d
+    he = hindcast_hist_obs_1d.isel(lead=range(3), init=range(10))
     if chunk:
         he = he.chunk({"lead": 2})
     else:
@@ -100,7 +100,7 @@ def test_bootstrap_hindcast_resample_dim(
 ):
     """Test bootstrap_hindcast when resampling member or init and alignment
     same_inits."""
-    hindcast_hist_obs_1d.bootstrap(
+    hindcast_hist_obs_1d.isel(lead=range(3), init=range(10)).bootstrap(
         iterations=ITERATIONS,
         comparison="e2o",
         metric="mse",
@@ -232,6 +232,7 @@ def test_bootstrap_uninit_pm_ensemble_from_control_cftime_annual_identical_da(
 )
 def test_bootstrap_uninit_pm_ensemble_from_control_cftime_all_freq(init, control):
     """Test bootstrap_uninit_pm_ensemble_from_control_cftime for all freq data."""
+    init = init.isel(lead=range(3), init=range(5))
     uninit = bootstrap_uninit_pm_ensemble_from_control_cftime(init, control)
     # lead and member identical
     for d in ["lead", "member"]:
@@ -301,25 +302,6 @@ def test_bootstrap_by_stacking_two_var_dataset(
     assert res["init"].size == res_cf["init"].size
 
 
-@pytest.mark.slow
-@pytest.mark.parametrize("comparison", ["m2o", "e2o"])
-@pytest.mark.parametrize("metric", ["rmse", "pearson_r"])
-@pytest.mark.parametrize("alignment", VALID_ALIGNMENTS)
-def test_bootstrap_hindcast_alignment(
-    hindcast_hist_obs_1d, alignment, metric, comparison
-):
-    """Test bootstrap_hindcast for all alginments when resampling member."""
-    dim = "init" if comparison == "e2o" else ["member", "init"]
-    hindcast_hist_obs_1d.isel(lead=[0, 1, 2]).bootstrap(
-        iterations=ITERATIONS,
-        comparison=comparison,
-        metric=metric,
-        resample_dim="member",
-        alignment=alignment,
-        dim=dim,
-    )
-
-
 def test_bootstrap_hindcast_raises_error(
     hind_da_initialized_1d, hist_da_uninitialized_1d, observations_da_1d
 ):
@@ -366,7 +348,7 @@ def test_resample_size(PM_da_initialized_1d):
 @pytest.mark.parametrize("replace", [True, False])
 def test_resample_iterations_same(PM_da_initialized_1d, chunk, replace):
     """Test that both `resample_iterations` functions yield same result shape."""
-    ds = PM_da_initialized_1d
+    ds = PM_da_initialized_1d.isel(lead=range(3), init=range(5))
     if chunk:
         ds = ds.chunk()
     ds_r_idx = _resample_iterations_idx(ds, ITERATIONS, "member", replace=replace)
@@ -401,7 +383,7 @@ def test_chunk_before_resample_iterations_idx(PM_da_initialized_3d_full):
 @pytest.mark.parametrize("replace", [True, False])
 def test_resample_iterations_dim_max(PM_da_initialized_1d, chunk, replace):
     """Test that both `resample_iterations(dim_max=n)` gives n members."""
-    ds = PM_da_initialized_1d.copy()
+    ds = PM_da_initialized_1d.isel(lead=range(3), init=range(5))
     ds = ds.sel(member=list(ds.member.values) * 2)
     ds["member"] = np.arange(1, 1 + ds.member.size)
     if chunk:

--- a/climpred/tests/test_metrics_perfect.py
+++ b/climpred/tests/test_metrics_perfect.py
@@ -93,7 +93,7 @@ def test_HindcastEnsemble_constant_forecasts(
 ):
     """Test that HindcastEnsemble.verify() returns a perfect score for a perfectly
     identical forecasts."""
-    he = hindcast_hist_obs_1d.isel(lead=[0, 1])
+    he = hindcast_hist_obs_1d.isel(lead=[0, 1], init=range(10))
     if how == "constant":  # replaces the variable with all 1's
         he = he.map(xr.ones_like)
     elif (

--- a/climpred/tests/test_metrics_perfect.py
+++ b/climpred/tests/test_metrics_perfect.py
@@ -30,7 +30,7 @@ def test_PerfectModelEnsemble_constant_forecasts(
 ):
     """Test that PerfectModelEnsemble.verify() returns a perfect score for a perfectly
     identical forecasts."""
-    pe = perfectModelEnsemble_initialized_control.isel(lead=[0, 1, 2])
+    pe = perfectModelEnsemble_initialized_control.isel(lead=[0, 1], init=[0, 1, 2])
     if how == "constant":  # replaces the variable with all 1's
         pe = pe.map(xr.ones_like)
     elif (
@@ -93,7 +93,7 @@ def test_HindcastEnsemble_constant_forecasts(
 ):
     """Test that HindcastEnsemble.verify() returns a perfect score for a perfectly
     identical forecasts."""
-    he = hindcast_hist_obs_1d.isel(lead=[0, 1, 2])
+    he = hindcast_hist_obs_1d.isel(lead=[0, 1])
     if how == "constant":  # replaces the variable with all 1's
         he = he.map(xr.ones_like)
     elif (

--- a/climpred/tests/test_probabilistic.py
+++ b/climpred/tests/test_probabilistic.py
@@ -169,27 +169,6 @@ def test_PerfectModelEnsemble_verify_bootstrap_not_nan_probabilistic(
                 assert not actual_skill.isnull().all()
 
 
-def test_compute_perfect_model_da1d_not_nan_crpss_quadratic(
-    PM_da_initialized_1d, PM_da_control_1d
-):
-    """
-    Checks that there are no NaNs on perfect model metrics of 1D time series.
-    """
-    actual = (
-        compute_perfect_model(
-            PM_da_initialized_1d.isel(lead=[0]),
-            PM_da_control_1d,
-            comparison="m2c",
-            metric="crpss",
-            gaussian=False,
-            dim="member",
-        )
-        .isnull()
-        .any()
-    )
-    assert not actual
-
-
 @pytest.mark.slow
 @pytest.mark.skip(reason="takes quite long")
 def test_compute_hindcast_da1d_not_nan_crpss_quadratic(
@@ -218,7 +197,7 @@ def test_hindcast_crpss_orientation(hind_da_initialized_1d, observations_da_1d):
     Checks that CRPSS hindcast as skill score > 0.
     """
     actual = compute_hindcast(
-        hind_da_initialized_1d.isel(lead=range(3), init=range(10)),
+        hind_da_initialized_1d.isel(lead=range(3)),
         observations_da_1d,
         comparison="m2o",
         metric="crpss",

--- a/climpred/tests/test_probabilistic.py
+++ b/climpred/tests/test_probabilistic.py
@@ -27,14 +27,12 @@ probabilistic_metrics_requiring_more_than_member_dim = [
 ]
 
 references = [
-    [],
     "uninitialized",
     "persistence",
     "climatology",
     ["climatology", "uninitialized", "persistence"],
 ]
 references_ids = [
-    "empty list",
     "uninitialized",
     "persistence",
     "climatology",
@@ -54,7 +52,7 @@ def test_HindcastEnsemble_verify_bootstrap_probabilistic(
     Checks that HindcastEnsemble.verify() and HindcastEnsemble.bootstrap() works
     without breaking for all probabilistic metrics.
     """
-    he = hindcast_hist_obs_1d.isel(lead=[0, 1, 2])
+    he = hindcast_hist_obs_1d.isel(lead=[0, 1])
 
     category_edges = np.array([-0.5, 0, 0.5])
     if metric in probabilistic_metrics_requiring_logical:

--- a/climpred/tests/test_probabilistic.py
+++ b/climpred/tests/test_probabilistic.py
@@ -52,7 +52,7 @@ def test_HindcastEnsemble_verify_bootstrap_probabilistic(
     Checks that HindcastEnsemble.verify() and HindcastEnsemble.bootstrap() works
     without breaking for all probabilistic metrics.
     """
-    he = hindcast_hist_obs_1d.isel(lead=[0, 1])
+    he = hindcast_hist_obs_1d.isel(lead=[0, 1], init=range(10))
 
     category_edges = np.array([-0.5, 0, 0.5])
     if metric in probabilistic_metrics_requiring_logical:
@@ -120,7 +120,7 @@ def test_PerfectModelEnsemble_verify_bootstrap_not_nan_probabilistic(
     """
     Checks that PerfectModelEnsemble.verify() and PerfectModelEnsemble.bootstrap() works without breaking for all probabilistic metrics.
     """
-    pm = perfectModelEnsemble_initialized_control.isel(lead=[0, 1, 2, 3])
+    pm = perfectModelEnsemble_initialized_control.isel(lead=range(3), init=range(5))
     kwargs = {
         "comparison": comparison,
         "metric": metric,
@@ -191,32 +191,6 @@ def test_compute_perfect_model_da1d_not_nan_crpss_quadratic(
 
 
 @pytest.mark.slow
-def test_compute_perfect_model_da1d_not_nan_crpss_quadratic_kwargs(
-    PM_da_initialized_1d, PM_da_control_1d
-):
-    """
-    Checks that there are no NaNs on perfect model metrics of 1D time series.
-    """
-    actual = (
-        compute_perfect_model(
-            PM_da_initialized_1d.isel(lead=[0]),
-            PM_da_control_1d,
-            comparison="m2c",
-            metric="crpss",
-            gaussian=False,
-            dim="member",
-            tol=1e-6,
-            xmin=None,
-            xmax=None,
-            cdf_or_dist=norm,
-        )
-        .isnull()
-        .any()
-    )
-    assert not actual
-
-
-@pytest.mark.slow
 @pytest.mark.skip(reason="takes quite long")
 def test_compute_hindcast_da1d_not_nan_crpss_quadratic(
     hind_da_initialized_1d, observations_da_1d
@@ -226,7 +200,7 @@ def test_compute_hindcast_da1d_not_nan_crpss_quadratic(
     """
     actual = (
         compute_hindcast(
-            hind_da_initialized_1d.isel(lead=[0, 1, 2]),
+            hind_da_initialized_1d.isel(lead=[0, 1, 2], init=range(10)),
             observations_da_1d,
             comparison="m2o",
             metric="crpss",
@@ -244,25 +218,9 @@ def test_hindcast_crpss_orientation(hind_da_initialized_1d, observations_da_1d):
     Checks that CRPSS hindcast as skill score > 0.
     """
     actual = compute_hindcast(
-        hind_da_initialized_1d,
+        hind_da_initialized_1d.isel(lead=range(3), init=range(10)),
         observations_da_1d,
         comparison="m2o",
-        metric="crpss",
-        dim="member",
-    )
-    if "init" in actual.coords:
-        actual = actual.mean("init")
-    assert not (actual.isel(lead=[0, 1]) < 0).any()
-
-
-def test_pm_crpss_orientation(PM_da_initialized_1d, PM_da_control_1d):
-    """
-    Checks that CRPSS in PM as skill score > 0.
-    """
-    actual = compute_perfect_model(
-        PM_da_initialized_1d,
-        PM_da_control_1d,
-        comparison="m2m",
         metric="crpss",
         dim="member",
     )
@@ -303,7 +261,7 @@ def test_compute_hindcast_probabilistic_metric_e2o_fails(
 
 
 def test_HindcastEnsemble_rps_terciles(hindcast_hist_obs_1d):
-    actual = hindcast_hist_obs_1d.verify(
+    actual = hindcast_hist_obs_1d.isel(lead=range(3), init=range(10)).verify(
         metric="rps",
         comparison="m2o",
         dim=["member", "init"],
@@ -320,7 +278,7 @@ def test_hindcast_verify_brier_logical(hindcast_recon_1d_ym):
     """Test that a probabilistic score requiring a binary observations and
     probability initialized inputs gives the same results whether passing logical
     as kwarg or mapping logical before for hindcast.verify()."""
-    he = hindcast_recon_1d_ym
+    he = hindcast_recon_1d_ym.isel(lead=range(3), init=range(10))
 
     def logical(ds):
         return ds > 0.5

--- a/climpred/tests/test_uninitialized.py
+++ b/climpred/tests/test_uninitialized.py
@@ -1,51 +1,8 @@
 import numpy as np
 import pytest
 
-from climpred.comparisons import HINDCAST_COMPARISONS
 from climpred.constants import VALID_ALIGNMENTS
-from climpred.metrics import DETERMINISTIC_HINDCAST_METRICS
 from climpred.reference import compute_uninitialized
-
-# uacc breaks
-DETERMINISTIC_HINDCAST_METRICS = DETERMINISTIC_HINDCAST_METRICS.copy()
-DETERMINISTIC_HINDCAST_METRICS.remove("uacc")
-
-
-@pytest.mark.parametrize("metric", DETERMINISTIC_HINDCAST_METRICS)
-@pytest.mark.parametrize("comparison", HINDCAST_COMPARISONS)
-def test_compute_uninitialized(
-    hind_ds_initialized_1d,
-    reconstruction_ds_1d,
-    hist_ds_uninitialized_1d,
-    metric,
-    comparison,
-):
-    """
-    Checks that compute uninitialized works without breaking.
-    """
-    category_edges = np.array([0.0, 0.5, 1.0])
-    if metric == "contingency":
-        metric_kwargs = {
-            "forecast_category_edges": category_edges,
-            "observation_category_edges": category_edges,
-            "score": "accuracy",
-        }
-    else:
-        metric_kwargs = {}
-    res = (
-        compute_uninitialized(
-            hind_ds_initialized_1d,
-            hist_ds_uninitialized_1d,
-            reconstruction_ds_1d,
-            metric=metric,
-            comparison=comparison,
-            **metric_kwargs
-        )
-        .isnull()
-        .any()
-    )
-    for var in res.data_vars:
-        assert not res[var]
 
 
 @pytest.mark.parametrize("alignment", VALID_ALIGNMENTS)

--- a/climpred/tutorial.py
+++ b/climpred/tutorial.py
@@ -179,7 +179,7 @@ def load_dataset(
         localmd5 = _file_md5_checksum(localfile)
         with open(md5file, "r") as f:
             remotemd5 = f.read()
-        if localmd5 != remotemd5:
+        if localmd5 != remotemd5 and False:
             _os.remove(localfile)
             msg = """
             Try downloading the file again. There was a confliction between

--- a/climpred/tutorial.py
+++ b/climpred/tutorial.py
@@ -82,10 +82,12 @@ def _get_datasets():
     for key in FILE_DESCRIPTIONS.keys():
         print(f"'{key}': {FILE_DESCRIPTIONS[key]}")
 
+
 def _cache_all():
     """Cache all datasets for pytest -n 4 woth pytest-xdist."""
     for d in aliases:
         load_dataset(d)
+
 
 def _initialize_proxy(proxy_dict):
     """Opens a proxy for firewalled servers so that the downloads can go
@@ -183,7 +185,7 @@ def load_dataset(
         localmd5 = _file_md5_checksum(localfile)
         with open(md5file, "r") as f:
             remotemd5 = f.read()
-        if localmd5 != remotemd5 and False:
+        if localmd5 != remotemd5:
             _os.remove(localfile)
             msg = """
             Try downloading the file again. There was a confliction between

--- a/climpred/tutorial.py
+++ b/climpred/tutorial.py
@@ -82,6 +82,10 @@ def _get_datasets():
     for key in FILE_DESCRIPTIONS.keys():
         print(f"'{key}': {FILE_DESCRIPTIONS[key]}")
 
+def _cache_all():
+    """Cache all datasets for pytest -n 4 woth pytest-xdist."""
+    for d in aliases:
+        load_dataset(d)
 
 def _initialize_proxy(proxy_dict):
     """Opens a proxy for firewalled servers so that the downloads can go


### PR DESCRIPTION
# Description

- [x] Reduce unnecessary tests
- [x] mpl-base
- [x] find the slowest tests using py.test xarray/tests/ --durations=100
- [x] Parallelise xdist breaks with loading from climpred-data: breaks only for py37. Try load all data before pytest in ci