### PR TITLE
fix xr < 0.18

### DIFF
--- a/climpred/tests/test_horizon.py
+++ b/climpred/tests/test_horizon.py
@@ -8,7 +8,7 @@ from climpred.horizon import _last_item_cond_true, horizon
 @pytest.mark.parametrize("input", ["DataArray", "Dataset"])
 @pytest.mark.parametrize("threshold,expected", [(1, 1), (2, 3), (3, 6), (3.5, 6)])
 def test_least_item_cond_true(threshold, expected, input):
-    """"test `last_item_cond_true` on artificial data."""
+    """test `last_item_cond_true` on artificial data."""
     ds = xr.DataArray(
         [1, 2, 2, 3, 3, 1, 4], dims="lead", coords={"lead": np.arange(1, 1 + 7)}
     )
@@ -83,7 +83,7 @@ def test_horizon_smooth(perfectModelEnsemble_initialized_control, smooth):
 
 
 def test_horizon_weird_coords():
-    """"Test horizon for weird coords."""
+    """Test horizon for weird coords."""
     cond = xr.DataArray([True] * 10, dims="lead").to_dataset(name="SST")
     # Change leads to something weird
     cond["lead"] = [0.25, 0.75, 1, 3, 4, 5, 6, 7, 8, 9]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-xarray>=0.16.1
+xarray<0.18
 dask!=2021.03.0
 matplotlib
 ipython


### PR DESCRIPTION
upstream fix: https://github.com/xarray-contrib/xskillscore/pull/309, here temporary for `main`, next release earliest once `xs` is patched