### PR TITLE
allow model dim in initialized when not in obs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,10 @@ New Features
 - Allow ``weekofyear`` via ``datetime`` in
   :py:meth:`~climpred.classes.HindcastEnsemble.remove_bias`, but not yet implemented in
   ``verify(reference='climatology')``. (:issue:`529`, :pr:`603`) `Aaron Spring`_.
+- Allow more dimensions in ``initialized`` than in ``observations``. This is particular
+  useful if you have forecasts from multiple models (in a ``model`` dimension) and want
+  to verify against the same observations.
+  (:issue:`129`, :issue:`528`, :pr:`619`) `Aaron Spring`_.
 
 Documentation
 -------------

--- a/ci/requirements/climpred-dev.yml
+++ b/ci/requirements/climpred-dev.yml
@@ -55,3 +55,4 @@ dependencies:
   - pip:
       - pytest-lazy-fixture
       - nb_black  # notebook linting
+      - git+https://github.com/aulemahal/nc-time-axis.git@remove-utime

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -20,4 +20,5 @@ dependencies:
   - pip
   - pip:
     # Install latest version of climpred.
+    - git+https://github.com/aulemahal/nc-time-axis.git@remove-utime
     - -e ../..

--- a/ci/requirements/docs_notebooks.yml
+++ b/ci/requirements/docs_notebooks.yml
@@ -28,5 +28,6 @@ dependencies:
   - pip
   - pip:
     # Install latest version of climpred.
+    - git+https://github.com/aulemahal/nc-time-axis.git@remove-utime
     - -e ../..
     - nb_black

--- a/ci/requirements/minimum-tests.yml
+++ b/ci/requirements/minimum-tests.yml
@@ -25,4 +25,5 @@ dependencies:
   - xskillscore>=0.0.18
   - pip:
     - pytest-lazy-fixture
+    - git+https://github.com/aulemahal/nc-time-axis.git@remove-utime
     - -e ../..

--- a/climpred/bootstrap.py
+++ b/climpred/bootstrap.py
@@ -817,7 +817,8 @@ def bootstrap_compute(
             if isHindcast and comparison != __m2o:
                 bootstrapped_uninit_skill = bootstrapped_uninit_skill.mean("member")
 
-        bootstrapped_hind = resample_func(hind, iterations, resample_dim)
+        with xr.set_options(keep_attrs=True):
+            bootstrapped_hind = resample_func(hind, iterations, resample_dim)
         if dask.is_dask_collection(bootstrapped_hind):
             bootstrapped_hind = bootstrapped_hind.chunk({"member": -1})
 

--- a/climpred/checks.py
+++ b/climpred/checks.py
@@ -181,11 +181,14 @@ def match_initialized_dims(init, verif, uninitialized=False):
         init_dims.remove("lead")
     if ("member" in init_dims) and not uninitialized:
         init_dims.remove("member")
-    if not (set(verif.dims) == set(init_dims)):
+    if (set(verif.dims) - set(init.dims)) != set():
         unmatch_dims = set(verif.dims) ^ set(init_dims)
         raise DimensionError(
-            "Dimensions must match initialized prediction ensemble "
-            f"dimensions; these dimensions do not match: {unmatch_dims}."
+            f"Verification contains more dimensions than initialized. These dimensions do not match: {unmatch_dims}."
+        )
+    if (set(init.dims) - set(verif.dims)) != set():
+        warnings.warn(
+            f"Initialized contains more dimensions than verification. Dimension(s) {set(init.dims) - set(verif.dims)} will be broadcasted."
         )
     return True
 

--- a/climpred/tests/test_checks.py
+++ b/climpred/tests/test_checks.py
@@ -180,7 +180,7 @@ def test_match_initialized_dims_fail(da1, da2):
     """Test if check works if the da does not have the proper dims."""
     with pytest.raises(DimensionError) as e:
         match_initialized_dims(da1.rename({"y": "init"}), da2.rename({"y": "not_time"}))
-    assert "Dimensions must match initialized prediction" in str(e.value)
+    assert "Verification contains more dimensions than initialized" in str(e.value)
 
 
 def test_match_initialized_vars(ds1, ds2):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-xarray<0.18
+xarray
 dask!=2021.03.0
 matplotlib
 ipython


### PR DESCRIPTION
# Description

allow more dims in initialized than in observations, very useful for multi-model study with single observation product

Closes #129 #528 

## Type of change

Please delete options that are not relevant.

-   [x]  New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x]  pytest

## Checklist (while developing)

-   [x]  Tests added for `pytest`, if necessary.
-   [x]  CHANGELOG is updated with reference to this PR.
