### PR TITLE
attrs in coords

### DIFF
--- a/climpred/classes.py
+++ b/climpred/classes.py
@@ -186,10 +186,10 @@ class PredictionEnsemble:
         """Dictionary of xarray.DataArray objects corresponding to coordinate
         variables available in all PredictionEnsemble._datasets.
         """
-        pe_coords = self.get_initialized().coords.to_dataset(promote_attrs=True)
+        pe_coords = self.get_initialized().coords.to_dataset()
         for ds in self._datasets.values():
             if isinstance(ds, xr.Dataset):
-                pe_coords.update(ds.coords.to_dataset(promote_attrs=True))
+                pe_coords.update(ds.coords.to_dataset())
         return pe_coords.coords
 
     @property

--- a/climpred/classes.py
+++ b/climpred/classes.py
@@ -186,10 +186,10 @@ class PredictionEnsemble:
         """Dictionary of xarray.DataArray objects corresponding to coordinate
         variables available in all PredictionEnsemble._datasets.
         """
-        pe_coords = self.get_initialized().coords.to_dataset()
+        pe_coords = self.get_initialized().coords.to_dataset(promote_attrs=True)
         for ds in self._datasets.values():
             if isinstance(ds, xr.Dataset):
-                pe_coords.update(ds.coords.to_dataset())
+                pe_coords.update(ds.coords.to_dataset(promote_attrs=True))
         return pe_coords.coords
 
     @property

--- a/climpred/tests/test_PredictionEnsemble.py
+++ b/climpred/tests/test_PredictionEnsemble.py
@@ -434,17 +434,17 @@ def test_PredictionEnsemble_cf(pe):
     # standard_names
     for k, v in CF_STANDARD_NAMES.items():
         if k in pe.coords:
-            assert v == pe.get_initialized().coords[k].attrs["standard_name"]
+            assert v == pe.coords[k].attrs["standard_name"]
 
     # long_names
     for k, v in CF_LONG_NAMES.items():
         if k in pe.coords:
-            assert v == pe.get_initialized().coords[k].attrs["long_name"]
+            assert v == pe.coords[k].attrs["long_name"]
 
     # description
     for k, v in CF_LONG_NAMES.items():
         if k in pe.coords:
-            assert len(pe.get_initialized().coords[k].attrs["description"]) > 5
+            assert len(pe.coords[k].attrs["description"]) > 5
 
 
 def test_warn_if_chunked_along_init_member_time(


### PR DESCRIPTION
# Description

doesnt work. `promote_attrs` not in `coordinate.to_dataset()` also not needed

Adding to #639 and #568
