### PR TITLE
add tests to show #586 can be closed

### DIFF
--- a/climpred/alignment.py
+++ b/climpred/alignment.py
@@ -48,7 +48,7 @@ def return_inits_and_verif_dates(forecast, verif, alignment, reference=None, his
 
     # If aligning reference='uninitialized', need to account for potential differences
     # in its temporal coverage. Note that the reference='uninitialized' only aligns
-    # verification dates and doesn't care about inits.
+    # verification dates and doesn't need to care about inits.
     if hist is not None:
         all_verifs = np.sort(list(set(all_verifs.data) & set(hist["time"].data)))
         all_verifs = xr.DataArray(all_verifs, dims=["time"], coords=[all_verifs])
@@ -56,9 +56,9 @@ def return_inits_and_verif_dates(forecast, verif, alignment, reference=None, his
     # Construct list of `n` offset over all leads.
     n, freq = get_multiple_lead_cftime_shift_args(units, leads)
 
-    if "valid_time" not in forecast.coords:  # old
+    if "valid_time" not in forecast.coords:  # old: create init_lead_matrix
         init_lead_matrix = _construct_init_lead_matrix(forecast, n, freq, leads)
-    else:  # new
+    else:  # new: use valid_time(init, lead)
         init_lead_matrix = forecast["valid_time"].drop("valid_time").rename(None)
     if dask.is_dask_collection(init_lead_matrix):
         init_lead_matrix = init_lead_matrix.compute()

--- a/climpred/reference.py
+++ b/climpred/reference.py
@@ -60,7 +60,7 @@ def climatology(verif, inits, verif_dates, lead):
 
 
 def uninitialized(hist, verif, verif_dates, lead):
-    """also called historical in some communities."""
+    """Uninitialized forecast uses a simulation without any initialization (assimilation/nudging). Also called historical in some communities."""
     lforecast = hist.sel(time=verif_dates[lead])
     lverif = verif.sel(time=verif_dates[lead])
     return lforecast, lverif

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ netcdf4
 nc-time-axis>=1.3.1
 bias-correction>=0.4
 cf_xarray>=0.6.0
-xclim>=0.29
+xclim==0.29


### PR DESCRIPTION
# Description

comment was misleading. alignment already takes care of alignment via `all_verifs`

Closes #586

Fix `xclim==0.29`

fix plot(x='time') works as default

## To-Do List

<!-- Feel free to add a checklist of steps to be performed while you are working through creating this PR. -->

## Type of change

<!-- Please delete options that are not relevant.-->

-   [ ]  Bug fix (non-breaking change which fixes an issue)
-   [ ]  New feature (non-breaking change which adds functionality)
-   [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ]  This change requires a documentation update
-   [ ]  Performance (if you modified existing code run `asv` to detect performance changes)
-   [ ]  Refactoring
-   [ ]  Improved Documentation

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. This could point to a cell in the updated notebooks. Or a snippet of code with accompanying figures here. -->

-   [x]  Tests added for `pytest`, if necessary.

## Checklist (while developing)

-   [ ]  I have added docstrings to all new functions.
-   [ ]  I have commented my code, particularly in hard-to-understand areas.
-   [ ]  I have updated the sphinx documentation, if necessary.
-   [ ]  Any new functions are added to the API. (See contribution guide)
-   [ ]  CHANGELOG is updated with reference to this PR.

## References

<!-- Please add any references to manuscripts, textbooks, etc. if applicable -->
