### PR TITLE
`isin` on `asi8` instead of `cftime`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,9 @@ Internals/Minor Fixes
 - Refactor ``asv`` benchmarking. Add ``run-benchmarks`` label to ``PR`` to run ``asv``
   via Github Actions. (:issue:`664`, :pr:`718`) `Aaron Spring`_.
 - Remove ``ipython`` from ``requirements.txt``. (:pr:`720`) `Aaron Spring`_.
+- Calculating ``np.isin`` on ``asi8``(``float``) instead of ``xr.CFTimeIndex`` speeds up
+  :py:meth:`.HindcastEnsemble.verify` and :py:meth:`.HindcastEnsemble.bootstrap` with
+  large number of inits. (:issue:`414`, :pr:`724`) `Aaron Spring`_.
 
 
 climpred v2.2.0 (2021-12-20)

--- a/climpred/alignment.py
+++ b/climpred/alignment.py
@@ -15,12 +15,22 @@ returnType = Tuple[Dict[float, xr.DataArray], Dict[float, xr.CFTimeIndex]]
 
 
 def _isin(init_lead_matrix: xr.DataArray, all_verifs: xr.DataArray) -> xr.DataArray:
-    init_lead_asi8 = np.vstack(
-        [init_lead_matrix.sel(lead=i).to_index().asi8 for i in init_lead_matrix.lead]
-    )
     if not isinstance(all_verifs, xr.CFTimeIndex):
         all_verifs = all_verifs.to_index()
-    isin = np.isin(init_lead_asi8, all_verifs.asi8)
+    if len(init_lead_matrix.dims) == 2:
+        init_lead_asi8 = np.vstack(
+            [
+                init_lead_matrix.sel(lead=i).to_index().asi8
+                for i in init_lead_matrix.lead
+            ]
+        )
+        isin = np.isin(init_lead_asi8, all_verifs.asi8)
+    elif len(init_lead_matrix.dims) == 1:
+        if not isinstance(init_lead_matrix, xr.CFTimeIndex):
+            init_lead_matrix2 = init_lead_matrix.to_index()
+        else:
+            init_lead_matrix2 = init_lead_matrix
+        isin = np.isin(init_lead_matrix2.asi8, all_verifs.asi8)
     return xr.DataArray(
         data=isin,
         dims=init_lead_matrix.dims,

--- a/climpred/classes.py
+++ b/climpred/classes.py
@@ -2648,4 +2648,11 @@ class HindcastEnsemble(PredictionEnsemble):
                     .coords["valid_time"]
                     .isel(member=0, drop=True)
                 )
+        # to avoid ValueError: conflicting sizes for dimension 'time': length 1 on the
+        # data but length n on coordinate 'time'
+        if "valid_time" in self.get_initialized().coords:
+            if self.get_initialized().coords["valid_time"].isnull().any():
+                self._datasets["initialized"] = self._datasets["initialized"].dropna(
+                    "init"
+                )
         return self

--- a/climpred/tests/test_alignment.py
+++ b/climpred/tests/test_alignment.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 import xskillscore as xs
 
+from climpred.alignment import _isin
 from climpred.exceptions import CoordinateError
 from climpred.prediction import compute_hindcast
 
@@ -176,3 +177,18 @@ def test_maximize_alignment_verifs(
                 assert (
                     f"verifs: {1955+i}-01-01 00:00:00-2017-01-01 00:00:00" in record[2]
                 )
+
+
+def test_my_isin(hindcast_recon_1d_ym):
+    """Test _isin function calc on asi8 instead of xr.CFTimeIndex is equvi to isin."""
+    he = hindcast_recon_1d_ym
+    all_verifs = he.get_observations()["time"]
+    init_lead_matrix = (
+        he.coords["valid_time"]
+        .drop_vars("valid_time")
+        .rename(None)
+        .rename({"init": "time"})
+    )
+    previous = init_lead_matrix.isin(all_verifs)
+    faster = _isin(init_lead_matrix, all_verifs)
+    assert previous.equals(faster)

--- a/climpred/tests/test_bias_removal.py
+++ b/climpred/tests/test_bias_removal.py
@@ -229,6 +229,7 @@ def test_remove_bias_unfair_artificial_skill_over_fair(
             alignment=alignment,
             train_test_split="unfair",
         )
+
         unfair_skill = he_unfair.verify(**verify_kwargs)
 
         print("\n unfair-cv \n")


### PR DESCRIPTION
# Description

- `xr.DataArray.coords['init'].isin(xr.DataArray.coords['time'])` is slow
- dont use `isin` on `xr.CFTimeIndex`-backed `xr.DataArray` but after converting to index and `asi8` (e.g. 'ms since 1970')

Closes #414 

## Type of change

<!-- Please delete options that are not relevant.-->

-   [x]  Performance (if you modified existing code run `asv` to detect performance changes)
-   [x]  Refactoring

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. This could point to a cell in the updated notebooks. Or a snippet of code with accompanying figures here. -->

-   [x]  Tests added for `pytest`, if necessary.

## Checklist (while developing)

-   [x]  I have added docstrings to all new functions.
-   [x]  CHANGELOG is updated with reference to this PR.