### PR TITLE
resolve `ImportError` for `version`

### DIFF
--- a/.github/workflows/comment_binder_pr_link.yml
+++ b/.github/workflows/comment_binder_pr_link.yml
@@ -15,6 +15,6 @@ jobs:
         with:
           message: >-
             Checkout your PR on
-            [![Binder](https://mybinder.org/v2/gh/pangeo-data/climpred/${{github.head_ref}}?urlpath=lab%2Ftree%2Fdocs%2Fsource%2Fquick-start.ipynb).
+            [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/pangeo-data/climpred/${{github.head_ref}}?urlpath=lab%2Ftree%2Fdocs%2Fsource%2Fquick-start.ipynb).
             Open the console and `pip install -e .` before using the notebooks to use `climpred` from this PR.
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/climpred/utils.py
+++ b/climpred/utils.py
@@ -24,8 +24,9 @@ def add_attrs_to_climpred_coords(results):
     """Write attrs for coords added by climpred."""
     try:
         from . import __version__ as version
+        version = f"v{version}"
     except ImportError:
-        version = "version"
+        version = "stable"
 
     if "results" in results.coords:
         results["results"] = results["results"].assign_attrs(
@@ -41,7 +42,7 @@ def add_attrs_to_climpred_coords(results):
         results["skill"] = results["skill"].assign_attrs(
             {
                 "description": "new dimension prediction skill of initialized and reference forecasts created by .verify() or .bootstrap()",  # noqa: E501
-                "documentation": f"https://climpred.readthedocs.io/en/v{version}/reference_forecast.html",  # noqa: E501
+                "documentation": f"https://climpred.readthedocs.io/en/{version}/reference_forecast.html",  # noqa: E501
             }
         )
     if "skill" in results.dims:

--- a/climpred/utils.py
+++ b/climpred/utils.py
@@ -24,6 +24,7 @@ def add_attrs_to_climpred_coords(results):
     """Write attrs for coords added by climpred."""
     try:
         from . import __version__ as version
+
         version = f"v{version}"
     except ImportError:
         version = "stable"

--- a/climpred/utils.py
+++ b/climpred/utils.py
@@ -22,7 +22,10 @@ from .options import OPTIONS
 
 def add_attrs_to_climpred_coords(results):
     """Write attrs for coords added by climpred."""
-    from . import __version__ as version
+    try:
+        from . import __version__ as version
+    except ImportError:
+        version = "version"
 
     if "results" in results.coords:
         results["results"] = results["results"].assign_attrs(


### PR DESCRIPTION
# Description

resolve `ImportError` when installed `climpred` from `conda`. didnt break when installed via `pip`

```python
    def add_attrs_to_climpred_coords(results):
        """Write attrs for coords added by climpred."""
>       from . import __version__ as version
E       ImportError: cannot import name '__version__' from 'climpred'
```