### PR TITLE
fix `set_options(PerfectModel_persistence_from_initialized_lead_0=True)` multiple `reference` bug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,11 @@ Internals/Minor Fixes
   :py:meth:`.HindcastEnsemble.verify` and :py:meth:`.HindcastEnsemble.bootstrap` with
   large number of inits. (:issue:`414`, :pr:`724`) `Aaron Spring`_.
 
+Bug Fixes
+---------
+- Fix ``PerfectModel_persistence_from_initialized_lead_0=True`` with multiple
+  references. (:issue:`732`, :pr:`733`) `Aaron Spring`_.
+
 
 climpred v2.2.0 (2021-12-20)
 ============================

--- a/climpred/classes.py
+++ b/climpred/classes.py
@@ -1237,13 +1237,13 @@ class PerfectModelEnsemble(PredictionEnsemble):
         if reference:
             for r in reference:
                 dim_orig = deepcopy(dim)  # preserve dim, because
-                ref_compute_kwargs = metric_kwargs.copy()  # persistence changes dim
-                ref_compute_kwargs.update({"dim": dim_orig, "metric": metric})
-                if (
-                    not OPTIONS["PerfectModel_persistence_from_initialized_lead_0"]
-                    and r != "persistence"
-                ):
-                    ref_compute_kwargs["comparison"] = comparison
+                ref_compute_kwargs = deepcopy(metric_kwargs)  # persistence changes dim
+                ref_compute_kwargs.update(
+                    {"dim": dim_orig, "metric": metric, "comparison": comparison}
+                )
+                if r == "persistence":
+                    if not OPTIONS["PerfectModel_persistence_from_initialized_lead_0"]:
+                        del ref_compute_kwargs["comparison"]
                 ref = getattr(self, f"_compute_{r}")(**ref_compute_kwargs)
                 result = xr.concat([result, ref], dim="skill", **CONCAT_KWARGS)
             result = result.assign_coords(skill=["initialized"] + reference)

--- a/climpred/reference.py
+++ b/climpred/reference.py
@@ -506,6 +506,8 @@ def compute_persistence_from_first_lead(
         forecast.isel(lead=0, drop=True), observations, dim=dim, **metric_kwargs
     )
     persistence_skill["lead"] = persistence_skill.lead.values
+    if "forecast_member" in persistence_skill.dims:
+        persistence_skill = persistence_skill.mean("forecast_member")
     return persistence_skill
 
 

--- a/climpred/tests/test_reference.py
+++ b/climpred/tests/test_reference.py
@@ -28,7 +28,7 @@ def test_PerfectModelEnsemble_verify_persistence_from_first_lead(
         metric="mse",
         comparison=comparison,
         dim="init" if comparison == "e2c" else ["member", "init"],
-        reference="persistence",
+        reference=["persistence", "climatology"],
     )
     with set_options(PerfectModel_persistence_from_initialized_lead_0=True):
         new_persistence = perfectModelEnsemble_initialized_control.verify(**kw)

--- a/climpred/tests/test_reference.py
+++ b/climpred/tests/test_reference.py
@@ -37,6 +37,8 @@ def test_PerfectModelEnsemble_verify_persistence_from_first_lead(
     assert not new_persistence.sel(skill="persistence").equals(
         old_persistence.sel(skill="persistence")
     )
+    assert "forecast_member" not in new_persistence.dims
+    assert "forecast_member" not in old_persistence.dims
 
 
 @pytest.mark.parametrize("call", ["verify", "bootstrap"])


### PR DESCRIPTION
# Description

Closes #732

## Type of change

<!-- Please delete options that are not relevant.-->

-   [x]  Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. This could point to a cell in the updated notebooks. Or a snippet of code with accompanying figures here. -->

-   [x]  Tests added for `pytest`, if necessary.

## Checklist (while developing)

-   [x]  CHANGELOG is updated with reference to this PR.
