### PR TITLE
allow `datetime` after `__init__`

### DIFF
--- a/climpred/logging.py
+++ b/climpred/logging.py
@@ -20,20 +20,21 @@ def log_hindcast_verify_inits_and_verifs(
     """At each lead, log the inits and verification dates being used in computations."""
     if reference is None:
         reference = "initialized"
-    logging.info(
-        f"{reference} | lead: {str(lead).zfill(2)} | "
-        # This is the init-sliced forecast, thus displaying actual
-        # initializations.
-        f"inits: {inits[lead].min().values}"
-        f"-{inits[lead].max().values} | "
-        # This is the verification window, thus displaying the
-        # verification dates.
-        f"verifs: {verif_dates[lead].min()}"
-        f"-{verif_dates[lead].max()}"
-    )
     time_datetimeindex = (
         True if not isinstance(verif_dates[lead], xr.CFTimeIndex) else False
     )
+    if len(inits[lead]) > 1 or not time_datetimeindex:
+        logging.info(
+            f"{reference} | lead: {str(lead).zfill(2)} | "
+            # This is the init-sliced forecast, thus displaying actual
+            # initializations.
+            f"inits: {inits[lead].min().values}"
+            f"-{inits[lead].max().values} | "
+            # This is the verification window, thus displaying the
+            # verification dates.
+            f"verifs: {verif_dates[lead].min()}"
+            f"-{verif_dates[lead].max()}"
+        )
     init_output_iter = (
         inits[lead].to_index() if time_datetimeindex else inits[lead].values
     )

--- a/climpred/tests/test_logging.py
+++ b/climpred/tests/test_logging.py
@@ -14,3 +14,11 @@ def test_log_HindcastEnsemble_verify(hindcast_hist_obs_1d, caplog):
                 print(record)
                 assert all(x in record[2] for x in LOG_STRINGS)
                 assert "initialized" in record[2]
+
+
+def test_log_HindcastEnsemble_verify_datetime(hindcast_hist_obs_1d):
+    hindcast = hindcast_hist_obs_1d.copy()
+    hindcast.verify(metric="mse", comparison="e2o", dim="init", alignment="maximize")
+    # convert to datetime
+    hindcast = hindcast._convert_calendar("standard")
+    hindcast.verify(metric="mse", comparison="e2o", dim="init", alignment="maximize")


### PR DESCRIPTION
# Description

- resolves logging error when working with `datetime` internally after:
```python
# convert to datetime
hindcast._datasets['initialized'] = hindcast._datasets['initialized'].convert_calendar('standard',dim='init')
hindcast._datasets['initialized']['valid_time'] = xr.concat([hindcast._datasets['initialized'].sel(lead=l).swap_dims({'init':'valid_time'}).convert_calendar('standard',dim='valid_time').swap_dims({'valid_time':'init'}).valid_time for l in hindcast._datasets['initialized'].lead],'lead')
hindcast._datasets['observations'] = hindcast._datasets['observations'].convert_calendar('standard',dim='time’)
# now as hindcast._convert_calendar("standard")
```
- add `hindcast._convert_calendar("standard")` not a very clean solution - but works for now: a more clean solution would be to allow `DatetimeIndex` for shift and not converting to `CFTimeIndex` at `__init__`

Closes #(issue) @josephhardinee

## To-Do List

<!-- Feel free to add a checklist of steps to be performed while you are working through creating this PR. -->

## Type of change

<!-- Please delete options that are not relevant.-->

-   [x]  New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. This could point to a cell in the updated notebooks. Or a snippet of code with accompanying figures here. -->

-   [x]  Tests added for `pytest`, if necessary.

## Checklist (while developing)

-   [ ]  I have added docstrings to all new functions.
-   [ ]  I have commented my code, particularly in hard-to-understand areas.
-   [ ]  I have updated the sphinx documentation, if necessary.
-   [ ]  Any new functions are added to the API. (See contribution guide)
-   [ ]  CHANGELOG is updated with reference to this PR.

## References

<!-- Please add any references to manuscripts, textbooks, etc. if applicable -->
