### PR TITLE
fix single `lead` dim not dropped in `remove_bias`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,9 @@ Bug Fixes
 - :py:meth:`.HindcastEnsemble.verify`
   ``(comparison="m2o", reference="uninitialized", dim="init")``.
   (:issue:`735`, :pr:`731`) `Aaron Spring`_.
+- :py:meth:`.HindcastEnsemble.remove_bias`
+  does not drop single item ``lead`` dimension.
+  (:issue:`771`, :pr:`773`) `Aaron Spring`_.
 
 New Features
 ------------

--- a/climpred/classes.py
+++ b/climpred/classes.py
@@ -2815,6 +2815,11 @@ class HindcastEnsemble(PredictionEnsemble):
                 )
         # avoid single-item lead dimension being dropped, see #771
         for c in ["lead", "init"]:
-            if c in self.get_initialized().coords and c not in self.get_initialized().dims:
-                self._datasets["initialized"] = self._datasets["initialized"].expand_dims(c)
+            if (
+                c in self.get_initialized().coords
+                and c not in self.get_initialized().dims
+            ):
+                self._datasets["initialized"] = self._datasets[
+                    "initialized"
+                ].expand_dims(c)
         return self

--- a/climpred/classes.py
+++ b/climpred/classes.py
@@ -2820,5 +2820,5 @@ class HindcastEnsemble(PredictionEnsemble):
                 if old_coords[c].size == 1:
                     self._datasets["initialized"] = self._datasets[
                         "initialized"
-                    ].assign_coords(c=old_coords[c])
+                    ].assign_coords({c:old_coords[c]})
         return self

--- a/climpred/classes.py
+++ b/climpred/classes.py
@@ -2818,8 +2818,7 @@ class HindcastEnsemble(PredictionEnsemble):
         for c in ["lead", "init"]:
             if c not in self.get_initialized().dims and c in old_coords:
                 if old_coords[c].size == 1:
-                    self._datasets["initialized"] = (
-                        self._datasets["initialized"]
-                        .assign_coords(c=old_coords[c])
-                    )
+                    self._datasets["initialized"] = self._datasets[
+                        "initialized"
+                    ].assign_coords(c=old_coords[c])
         return self

--- a/climpred/classes.py
+++ b/climpred/classes.py
@@ -2813,4 +2813,8 @@ class HindcastEnsemble(PredictionEnsemble):
                 self._datasets["initialized"] = self._datasets["initialized"].dropna(
                     "init"
                 )
+        # avoid single-item lead dimension being dropped, see #771
+        for c in ["lead", "init"]:
+            if c in self.get_initialized().coords and c not in self.get_initialized().dims:
+                self._datasets["initialized"] = self._datasets["initialized"].expand_dims(c)
         return self

--- a/climpred/classes.py
+++ b/climpred/classes.py
@@ -2821,4 +2821,15 @@ class HindcastEnsemble(PredictionEnsemble):
                     self._datasets["initialized"] = self._datasets[
                         "initialized"
                     ].assign_coords({c: old_coords[c]})
+        if "valid_time" in self.get_initialized().coords:
+            if len(self.get_initialized().coords["valid_time"].dims) == 1 and set(
+                ["init", "lead"]
+            ).issubset(set(self.get_initialized().dims)):
+                self._datasets["initialized"].coords[
+                    "valid_time"
+                ] = add_time_from_init_lead(
+                    self.get_initialized().drop("valid_time")
+                ).coords[
+                    "valid_time"
+                ]
         return self

--- a/climpred/classes.py
+++ b/climpred/classes.py
@@ -2789,6 +2789,7 @@ class HindcastEnsemble(PredictionEnsemble):
                 )
             metric_kwargs["cv"] = cv
 
+        old_coords = self.get_initialized().coords
         self = func(
             self,
             alignment=alignment,
@@ -2815,11 +2816,9 @@ class HindcastEnsemble(PredictionEnsemble):
                 )
         # avoid single-item lead dimension being dropped, see #771
         for c in ["lead", "init"]:
-            if (
-                c in self.get_initialized().coords
-                and c not in self.get_initialized().dims
-            ):
-                self._datasets["initialized"] = self._datasets[
+            if c not in self.get_initialized().dims and c in old_coords:
+                if old_coords[c].size == 1:
+                    self._datasets["initialized"] = self._datasets[
                     "initialized"
-                ].expand_dims(c)
+                ].assign_coords(c=old_coords_c).expand_dims(c)
         return self

--- a/climpred/classes.py
+++ b/climpred/classes.py
@@ -2820,7 +2820,7 @@ class HindcastEnsemble(PredictionEnsemble):
                 if old_coords[c].size == 1:
                     self._datasets["initialized"] = (
                         self._datasets["initialized"]
-                        .assign_coords(c=old_coords_c)
+                        .assign_coords(c=old_coords[c])
                         .expand_dims(c)
                     )
         return self

--- a/climpred/classes.py
+++ b/climpred/classes.py
@@ -2818,7 +2818,9 @@ class HindcastEnsemble(PredictionEnsemble):
         for c in ["lead", "init"]:
             if c not in self.get_initialized().dims and c in old_coords:
                 if old_coords[c].size == 1:
-                    self._datasets["initialized"] = self._datasets[
-                    "initialized"
-                ].assign_coords(c=old_coords_c).expand_dims(c)
+                    self._datasets["initialized"] = (
+                        self._datasets["initialized"]
+                        .assign_coords(c=old_coords_c)
+                        .expand_dims(c)
+                    )
         return self

--- a/climpred/classes.py
+++ b/climpred/classes.py
@@ -2821,6 +2821,5 @@ class HindcastEnsemble(PredictionEnsemble):
                     self._datasets["initialized"] = (
                         self._datasets["initialized"]
                         .assign_coords(c=old_coords[c])
-                        .expand_dims(c)
                     )
         return self

--- a/climpred/classes.py
+++ b/climpred/classes.py
@@ -2820,5 +2820,5 @@ class HindcastEnsemble(PredictionEnsemble):
                 if old_coords[c].size == 1:
                     self._datasets["initialized"] = self._datasets[
                         "initialized"
-                    ].assign_coords({c:old_coords[c]})
+                    ].assign_coords({c: old_coords[c]})
         return self

--- a/climpred/tests/test_bias_removal.py
+++ b/climpred/tests/test_bias_removal.py
@@ -543,3 +543,10 @@ def test_remove_bias_errors(hindcast_NMME_Nino34):
             NotImplementedError, match="Please choose `train_test_split` from"
         ):
             he.remove_bias(how="new", alignment="same_verif", train_test_split="tts")
+
+
+def test_remove_bias_errors(hindcast_NMME_Nino34):
+    """Test remove_bias doesnt drop single-item lead dimension."""
+    detrended = hindcast_NMME_Nino34.isel(lead=[0]).remove_bias(how="additive_mean", alignment="same_verifs")
+    assert "lead" in detrended.get_initialized().dims
+    detrended.verify()

--- a/climpred/tests/test_bias_removal.py
+++ b/climpred/tests/test_bias_removal.py
@@ -552,6 +552,7 @@ def test_remove_bias_dont_drop(hindcast_NMME_Nino34):
         how="additive_mean", alignment=alignment
     )
     assert "lead" in detrended.get_initialized().dims
+    assert len(detrended.get_initialized().coords["valid_time"].dims) == 2
     detrended.verify(
         metric="rmse",
         comparison="e2o",

--- a/climpred/tests/test_bias_removal.py
+++ b/climpred/tests/test_bias_removal.py
@@ -547,6 +547,8 @@ def test_remove_bias_errors(hindcast_NMME_Nino34):
 
 def test_remove_bias_errors(hindcast_NMME_Nino34):
     """Test remove_bias doesnt drop single-item lead dimension."""
-    detrended = hindcast_NMME_Nino34.isel(lead=[0]).remove_bias(how="additive_mean", alignment="same_verifs")
+    detrended = hindcast_NMME_Nino34.isel(lead=[0]).remove_bias(
+        how="additive_mean", alignment="same_verifs"
+    )
     assert "lead" in detrended.get_initialized().dims
     detrended.verify()

--- a/climpred/tests/test_bias_removal.py
+++ b/climpred/tests/test_bias_removal.py
@@ -553,5 +553,5 @@ def test_remove_bias_dont_drop(hindcast_NMME_Nino34):
     assert "lead" in detrended.get_initialized().dims
     print(detrended.get_initialized())
     detrended.verify(
-        metric="rmse", comparison="e2o", dim="init", alignment="same_inits"
+        metric="rmse", comparison="e2o", dim="init", alignment="same_verifs“
     )

--- a/climpred/tests/test_bias_removal.py
+++ b/climpred/tests/test_bias_removal.py
@@ -551,7 +551,6 @@ def test_remove_bias_dont_drop(hindcast_NMME_Nino34):
         how="additive_mean", alignment="same_verifs"
     )
     assert "lead" in detrended.get_initialized().dims
-    detrended.verify(metric="rmse",
-            comparison="e2o",
-            dim="init",
-            alignment="same_inits")
+    detrended.verify(
+        metric="rmse", comparison="e2o", dim="init", alignment="same_inits"
+    )

--- a/climpred/tests/test_bias_removal.py
+++ b/climpred/tests/test_bias_removal.py
@@ -551,4 +551,7 @@ def test_remove_bias_dont_drop(hindcast_NMME_Nino34):
         how="additive_mean", alignment="same_verifs"
     )
     assert "lead" in detrended.get_initialized().dims
-    detrended.verify()
+    detrended.verify(metric="rmse",
+            comparison="e2o",
+            dim="init",
+            alignment="same_inits")

--- a/climpred/tests/test_bias_removal.py
+++ b/climpred/tests/test_bias_removal.py
@@ -552,5 +552,8 @@ def test_remove_bias_dont_drop(hindcast_NMME_Nino34):
     )
     assert "lead" in detrended.get_initialized().dims
     detrended.verify(
-        metric="rmse", comparison="e2o", dim="init", alignment="same_verifs",
+        metric="rmse",
+        comparison="e2o",
+        dim="init",
+        alignment="same_verifs",
     )

--- a/climpred/tests/test_bias_removal.py
+++ b/climpred/tests/test_bias_removal.py
@@ -547,13 +547,14 @@ def test_remove_bias_errors(hindcast_NMME_Nino34):
 
 def test_remove_bias_dont_drop(hindcast_NMME_Nino34):
     """Test remove_bias doesnt drop single-item lead dimension."""
+    alignment="same_inits"
     detrended = hindcast_NMME_Nino34.isel(lead=[0]).remove_bias(
-        how="additive_mean", alignment="same_verifs"
+        how="additive_mean", alignment=alignment
     )
     assert "lead" in detrended.get_initialized().dims
     detrended.verify(
         metric="rmse",
         comparison="e2o",
         dim="init",
-        alignment="same_verifs",
+        alignment=alignment,
     )

--- a/climpred/tests/test_bias_removal.py
+++ b/climpred/tests/test_bias_removal.py
@@ -551,7 +551,6 @@ def test_remove_bias_dont_drop(hindcast_NMME_Nino34):
         how="additive_mean", alignment="same_verifs"
     )
     assert "lead" in detrended.get_initialized().dims
-    print(detrended.get_initialized())
     detrended.verify(
-        metric="rmse", comparison="e2o", dim="init", alignment="same_verifs“
+        metric="rmse", comparison="e2o", dim="init", alignment="same_verifs",
     )

--- a/climpred/tests/test_bias_removal.py
+++ b/climpred/tests/test_bias_removal.py
@@ -551,6 +551,7 @@ def test_remove_bias_dont_drop(hindcast_NMME_Nino34):
         how="additive_mean", alignment="same_verifs"
     )
     assert "lead" in detrended.get_initialized().dims
+    print(detrended.get_initialized())
     detrended.verify(
         metric="rmse", comparison="e2o", dim="init", alignment="same_inits"
     )

--- a/climpred/tests/test_bias_removal.py
+++ b/climpred/tests/test_bias_removal.py
@@ -545,7 +545,7 @@ def test_remove_bias_errors(hindcast_NMME_Nino34):
             he.remove_bias(how="new", alignment="same_verif", train_test_split="tts")
 
 
-def test_remove_bias_errors(hindcast_NMME_Nino34):
+def test_remove_bias_dont_drop(hindcast_NMME_Nino34):
     """Test remove_bias doesnt drop single-item lead dimension."""
     detrended = hindcast_NMME_Nino34.isel(lead=[0]).remove_bias(
         how="additive_mean", alignment="same_verifs"

--- a/climpred/tests/test_bias_removal.py
+++ b/climpred/tests/test_bias_removal.py
@@ -547,7 +547,7 @@ def test_remove_bias_errors(hindcast_NMME_Nino34):
 
 def test_remove_bias_dont_drop(hindcast_NMME_Nino34):
     """Test remove_bias doesnt drop single-item lead dimension."""
-    alignment="same_inits"
+    alignment = "same_inits"
     detrended = hindcast_NMME_Nino34.isel(lead=[0]).remove_bias(
         how="additive_mean", alignment=alignment
     )


### PR DESCRIPTION
# Description

`CLIMPRED_ENSEMBLE_DIMS` shouldnt be dropped

Closes #771 

## Type of change

<!-- Please delete options that are not relevant.-->

-   [x]  Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

-   [x]  Tests added for `pytest`, if necessary.

## Checklist (while developing)

-   [x]  CHANGELOG is updated with reference to this PR.