### PR TITLE
`alignment=same_verifs` `valid_time` should not contains any `NaN`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -72,6 +72,8 @@ Internals/Minor Fixes
   ``uninitialized`` skill with the iteration mean ``uninitialized``.
   Defaults to False., see :py:class:`~climpred.options.set_options`.
   (:pr:`731`) `Aaron Spring`_.
+- ``alignment="same_verifs"`` will not result in ``NaN``s in ``valid_time``.
+  (:pr:`777`) `Aaron Spring`_.
 
 Bug Fixes
 ---------

--- a/climpred/classes.py
+++ b/climpred/classes.py
@@ -2358,8 +2358,10 @@ class HindcastEnsemble(PredictionEnsemble):
         if self._temporally_smoothed:
             res = _reset_temporal_axis(res, self._temporally_smoothed, dim="lead")
             res["lead"].attrs = self.get_initialized().lead.attrs
-        
-        if "valid_time" in res.coords: # NaNs in valid_time only happen for same_verifs and dim=[]
+
+        if (
+            "valid_time" in res.coords
+        ):  # NaNs in valid_time only happen for same_verifs and dim=[]
             if res.coords["valid_time"].isnull().any():
                 res.coords["valid_time"] = self.get_initialized().coords["valid_time"]
 

--- a/climpred/classes.py
+++ b/climpred/classes.py
@@ -2358,6 +2358,10 @@ class HindcastEnsemble(PredictionEnsemble):
         if self._temporally_smoothed:
             res = _reset_temporal_axis(res, self._temporally_smoothed, dim="lead")
             res["lead"].attrs = self.get_initialized().lead.attrs
+        
+        if "valid_time" in res.coords: # NaNs in valid_time only happen for same_verifs and dim=[]
+            if res.coords["valid_time"].isnull().any():
+                res.coords["valid_time"] = self.get_initialized().coords["valid_time"]
 
         res = assign_attrs(
             res,

--- a/climpred/tests/test_alignment.py
+++ b/climpred/tests/test_alignment.py
@@ -199,9 +199,9 @@ def test_my_isin(hindcast_recon_1d_ym):
 def test_same_verifs_valid_time_no_nan(hindcast_hist_obs_1d):
     """Test that no NaNs are in valid_time coordinate for same_verifs."""
     skill = hindcast_hist_obs_1d.verify(
-            metric="rmse",
-            comparison="e2o",
-            dim=[], # important
-            alignment="same_verifs",
-        )
+        metric="rmse",
+        comparison="e2o",
+        dim=[],  # important
+        alignment="same_verifs",
+    )
     assert not skill.coords["valid_time"].isnull().any()

--- a/climpred/tests/test_alignment.py
+++ b/climpred/tests/test_alignment.py
@@ -194,3 +194,14 @@ def test_my_isin(hindcast_recon_1d_ym):
     previous = init_lead_matrix.isin(all_verifs)
     faster = _isin(init_lead_matrix, all_verifs)
     assert previous.equals(faster)
+
+
+def test_same_verifs_valid_time_no_nan(hindcast_hist_obs_1d):
+    """Test that no NaNs are in valid_time coordinate for same_verifs."""
+    skill = hindcast_hist_obs_1d.verify(
+            metric="rmse",
+            comparison="e2o",
+            dim=[], # important
+            alignment="same_verifs",
+        )
+    assert not skill.coords["valid_time"].isnull().any()


### PR DESCRIPTION
# Description

relates to #775 

## Type of change

<!-- Please delete options that are not relevant.-->

-   [x]  Bug fix (non-breaking change which fixes an issue)
-   [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. This could point to a cell in the updated notebooks. Or a snippet of code with accompanying figures here. -->

-   [x]  Tests added for `pytest`, if necessary.

## Checklist (while developing)

-   [x]  I have commented my code, particularly in hard-to-understand areas.
-   [x]  CHANGELOG is updated with reference to this PR.