### PR TITLE
`alignment=same_verifs` `valid_time` should not contains any `NaN` (#…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -72,6 +72,8 @@ Internals/Minor Fixes
   ``uninitialized`` skill with the iteration mean ``uninitialized``.
   Defaults to False., see :py:class:`~climpred.options.set_options`.
   (:pr:`731`) `Aaron Spring`_.
+- ``alignment="same_verifs"`` will not result in ``NaN``s in ``valid_time``.
+  (:pr:`777`) `Aaron Spring`_.
 
 Bug Fixes
 ---------

--- a/climpred/classes.py
+++ b/climpred/classes.py
@@ -2359,6 +2359,12 @@ class HindcastEnsemble(PredictionEnsemble):
             res = _reset_temporal_axis(res, self._temporally_smoothed, dim="lead")
             res["lead"].attrs = self.get_initialized().lead.attrs
 
+        if (
+            "valid_time" in res.coords
+        ):  # NaNs in valid_time only happen for same_verifs and dim=[]
+            if res.coords["valid_time"].isnull().any():
+                res.coords["valid_time"] = self.get_initialized().coords["valid_time"]
+
         res = assign_attrs(
             res,
             self.get_initialized(),

--- a/climpred/tests/test_alignment.py
+++ b/climpred/tests/test_alignment.py
@@ -194,3 +194,14 @@ def test_my_isin(hindcast_recon_1d_ym):
     previous = init_lead_matrix.isin(all_verifs)
     faster = _isin(init_lead_matrix, all_verifs)
     assert previous.equals(faster)
+
+
+def test_same_verifs_valid_time_no_nan(hindcast_hist_obs_1d):
+    """Test that no NaNs are in valid_time coordinate for same_verifs."""
+    skill = hindcast_hist_obs_1d.verify(
+        metric="rmse",
+        comparison="e2o",
+        dim=[],  # important
+        alignment="same_verifs",
+    )
+    assert not skill.coords["valid_time"].isnull().any()


### PR DESCRIPTION
…777)

* Update test_alignment.py

* [pre-commit.ci] auto fixes from pre-commit.com hooks

for more information, see https://pre-commit.ci

* Update classes.py

* [pre-commit.ci] auto fixes from pre-commit.com hooks

for more information, see https://pre-commit.ci

* Update CHANGELOG.rst

Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Closes #(issue)

## To-Do List

<!-- Feel free to add a checklist of steps to be performed while you are working through creating this PR. -->

## Type of change

<!-- Please delete options that are not relevant.-->

-   [ ]  Bug fix (non-breaking change which fixes an issue)
-   [ ]  New feature (non-breaking change which adds functionality)
-   [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ]  This change requires a documentation update
-   [ ]  Performance (if you modified existing code run `asv` to detect performance changes)
-   [ ]  Refactoring
-   [ ]  Improved Documentation

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. This could point to a cell in the updated notebooks. Or a snippet of code with accompanying figures here. -->

-   [ ]  Tests added for `pytest`, if necessary.

## Checklist (while developing)

-   [ ]  I have added docstrings to all new functions.
-   [ ]  I have commented my code, particularly in hard-to-understand areas.
-   [ ]  I have updated the sphinx documentation, if necessary.
-   [ ]  Any new functions are added to the API. (See contribution guide)
-   [ ]  CHANGELOG is updated with reference to this PR.

## References

<!-- Please add any references to manuscripts, textbooks, etc. if applicable -->
