### PR TITLE
Fix broken GEFS link

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ What's New
     # cut border when saving (for maps)
     mpl.rcParams["savefig.bbox"] = "tight"
 
+Internals/Minor Fixes
+---------------------
+- Fix broken GEFS link (:pr:`807`) `Trevor Gamblin`_
+
 climpred v2.3.0 (2022-11-25)
 ============================
 

--- a/docs/source/contributors.rst
+++ b/docs/source/contributors.rst
@@ -26,6 +26,7 @@ Contributors
 * Kathy Pegion (`github <https://github.com/kpegion/>`__)
 * Anderson Banihirwe (`github <https://github.com/andersy005/>`__)
 * Ray Bell (`github <https://github.com/raybellwaves/>`__)
+* Trevor Gamblin (`github <https://github.com/threexc/>`__)
 
 For a list of all the contributions, see the github
 `contribution graph <https://github.com/pangeo-data/climpred/graphs/contributors>`_.

--- a/docs/source/initialized-datasets.rst
+++ b/docs/source/initialized-datasets.rst
@@ -52,7 +52,7 @@ examples:
      - `IRIDL <examples/subseasonal/daily-S2S-IRIDL.html>`_, `EWC Cloud/climetlab <examples/subseasonal/daily-S2S-ECMWF.html>`_
    * - GEFS
      - weather
-     - `Global Ensemble Forecast System (GEFS) <https://www.ncdc.noaa.gov/data-access/model-data/model-datasets/global-ensemble-forecast-system-gefs>`_
+     - `Global Ensemble Forecast System (GEFS) <https://www.ncei.noaa.gov/products/weather-climate-models/global-ensemble-forecast>`_
      - `NOAA THREDDS <https://www.ncei.noaa.gov/thredds/catalog/model-gefs-003/catalog.html>`_
      - :cite:t:`Toth1993`
      - `GEFS NWP <examples/NWP/NWP_GEFS_6h_forecasts.html>`_


### PR DESCRIPTION
Signed-off-by: Trevor Gamblin <tvgamblin@gmail.com>

# Description

Noticed that the website link for the GEFS database returns a 404. Found the new URL and replaced the old one.

## Type of change

-   [*]  Improved Documentation

# How Has This Been Tested?

N/A

## References

N/A