### PR TITLE
No longer allow implicit optional (mypy)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,11 +49,11 @@ repos:
         exclude: 'asv_bench'
         additional_dependencies: [
             # Type stubs
-            types-python-dateutil,
-            types-pkg_resources,
             types-PyYAML,
+            types-pkg_resources,
+            types-python-dateutil,
             types-pytz,
-            typing-extensions==3.10.0.0,
+            typing-extensions,
             # Dependencies that are typed
             numpy,
           ]

--- a/climpred/classes.py
+++ b/climpred/classes.py
@@ -980,7 +980,7 @@ class PredictionEnsemble:
                     ndims.remove(d)
             if len(ndims) > 0:
                 msg += (
-                    f"\nConsider chunking embarassingly parallel dimensions such as "
+                    f"\nConsider chunking embarrassingly parallel dimensions such as "
                     f"{ndims} automatically, i.e. "
                     f'`{name}.chunk({ndims[0]}="auto").verify(...).'
                 )
@@ -988,15 +988,16 @@ class PredictionEnsemble:
 
     def _bootstrap(
         self,
-        metric: metricType = None,
-        comparison: comparisonType = None,
-        dim: dimType = None,
-        alignment: alignmentType = None,
-        reference: referenceType = None,
-        groupby: groupbyType = None,
-        iterations: int = None,
+        *,
+        metric: metricType,
+        comparison: comparisonType,
+        dim: Optional[dimType] = None,
+        alignment: Optional[alignmentType] = None,
+        reference: Optional[referenceType] = None,
+        groupby: Optional[groupbyType] = None,
+        iterations: Optional[int] = None,
         sig: int = 95,
-        resample_dim: str = None,
+        resample_dim: Optional[str] = None,
         **metric_kwargs: metric_kwargsType,
     ) -> xr.Dataset:
         """PredictionEnsemble.bootstrap() parent method.
@@ -1167,7 +1168,7 @@ class PredictionEnsemble:
         ]
         results_labels = ["verify skill", "low_ci", "high_ci"]
 
-        if reference != []:
+        if reference:
             pvalue = _pvalue_from_distributions(
                 resampled_skills.drop_sel(skill="initialized"),
                 resampled_skills.sel(skill="initialized"),
@@ -1347,11 +1348,12 @@ class PerfectModelEnsemble(PredictionEnsemble):
 
     def verify(
         self,
-        metric: metricType = None,
-        comparison: comparisonType = None,
-        dim: dimType = None,
-        reference: referenceType = None,
-        groupby: groupbyType = None,
+        *,
+        metric: metricType,
+        comparison: comparisonType,
+        dim: Optional[dimType] = None,
+        reference: Optional[referenceType] = None,
+        groupby: Optional[groupbyType] = None,
         **metric_kwargs: metric_kwargsType,
     ) -> xr.Dataset:
         """Verify initialized predictions against a configuration of its members.
@@ -1498,9 +1500,10 @@ class PerfectModelEnsemble(PredictionEnsemble):
 
     def _compute_uninitialized(
         self,
-        metric: metricType = None,
-        comparison: comparisonType = None,
-        dim: dimType = None,
+        *,
+        metric: metricType,
+        comparison: comparisonType,
+        dim: Optional[dimType] = None,
         **metric_kwargs: metric_kwargsType,
     ) -> xr.Dataset:
         """Verify the bootstrapped uninitialized run against itself.
@@ -1554,8 +1557,9 @@ class PerfectModelEnsemble(PredictionEnsemble):
 
     def _compute_persistence(
         self,
-        metric: metricType = None,
-        dim: dimType = None,
+        *,
+        metric: metricType,
+        dim: Optional[dimType] = None,
         **metric_kwargs: metric_kwargsType,
     ):
         """Verify a simple persistence forecast of the control run against itself.
@@ -1630,9 +1634,10 @@ class PerfectModelEnsemble(PredictionEnsemble):
 
     def _compute_climatology(
         self,
-        metric: metricType = None,
-        comparison: comparisonType = None,
-        dim: dimType = None,
+        *,
+        metric: metricType,
+        comparison: comparisonType,
+        dim: Optional[dimType] = None,
         **metric_kwargs: metric_kwargsType,
     ) -> xr.Dataset:
         """Verify a climatology forecast.
@@ -1681,11 +1686,12 @@ class PerfectModelEnsemble(PredictionEnsemble):
 
     def bootstrap(
         self,
-        metric: metricType = None,
-        comparison: comparisonType = None,
-        dim: dimType = None,
-        reference: referenceType = None,
-        groupby: groupbyType = None,
+        *,
+        metric: metricType,
+        comparison: comparisonType,
+        dim: Optional[dimType] = None,
+        reference: Optional[referenceType] = None,
+        groupby: Optional[groupbyType] = None,
         iterations: Optional[int] = None,
         sig: int = 95,
         resample_dim: str = "member",
@@ -2102,12 +2108,13 @@ class HindcastEnsemble(PredictionEnsemble):
 
     def verify(
         self,
-        metric: metricType = None,
-        comparison: comparisonType = None,
-        dim: dimType = None,
-        alignment: alignmentType = None,
-        reference: referenceType = None,
-        groupby: groupbyType = None,
+        *,
+        metric: metricType,
+        comparison: comparisonType,
+        dim: Optional[dimType] = None,
+        alignment: Optional[alignmentType] = None,
+        reference: Optional[referenceType] = None,
+        groupby: Optional[groupbyType] = None,
         **metric_kwargs: metric_kwargsType,
     ) -> xr.Dataset:
         """Verify the initialized ensemble against observations.
@@ -2409,12 +2416,13 @@ class HindcastEnsemble(PredictionEnsemble):
 
     def bootstrap(
         self,
-        metric: metricType = None,
-        comparison: comparisonType = None,
-        dim: dimType = None,
-        alignment: alignmentType = None,
-        reference: referenceType = None,
-        groupby: groupbyType = None,
+        *,
+        alignment: alignmentType,
+        metric: metricType,
+        comparison: comparisonType,
+        dim: Optional[dimType] = None,
+        reference: Optional[referenceType] = None,
+        groupby: Optional[groupbyType] = None,
         iterations: Optional[int] = None,
         sig: int = 95,
         resample_dim: str = "member",
@@ -2541,7 +2549,7 @@ class HindcastEnsemble(PredictionEnsemble):
 
     def remove_bias(
         self,
-        alignment: alignmentType = None,
+        alignment: alignmentType,
         how: str = "additive_mean",
         train_test_split: str = "unfair",
         train_init: Optional[Union[xr.DataArray, slice]] = None,

--- a/climpred/prediction.py
+++ b/climpred/prediction.py
@@ -144,7 +144,13 @@ def _sanitize_to_list(dim: Union[str, Set, Tuple, List, None]) -> Optional[List[
     return dim
 
 
-def _get_metric_comparison_dim(initialized, metric, comparison, dim, kind):
+def _get_metric_comparison_dim(
+    initialized,
+    metric,
+    comparison,
+    dim: Optional[Union[List[str], str]],
+    kind,
+):
     """Return `metric`, `comparison` and `dim` for compute functions.
 
     Args:

--- a/climpred/preprocessing/shared.py
+++ b/climpred/preprocessing/shared.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Union
+from typing import Any, Callable, Optional, Union
 
 import numpy as np
 import xarray as xr
@@ -10,10 +10,10 @@ from .mpi import get_path as get_path_mpi
 def load_hindcast(
     inits=range(1961, 1965, 1),
     members=range(1, 3, 1),
-    preprocess: Callable = None,
+    preprocess: Optional[Callable] = None,
     lead_offset: int = 1,
     parallel: bool = True,
-    engine: str = None,
+    engine: Optional[str] = None,
     get_path: Callable = get_path_mpi,
     **get_path_kwargs: Any,
 ) -> Union[xr.DataArray, xr.Dataset]:

--- a/climpred/utils.py
+++ b/climpred/utils.py
@@ -64,7 +64,7 @@ def assign_attrs(
     dim=None,
     **kwargs,
 ):
-    """Write information about prediction skill into attrs.
+    r"""Write information about prediction skill into attrs.
 
     Args:
         skill (`xarray` object): prediction skill.
@@ -75,7 +75,7 @@ def assign_attrs(
         metric (class) : metric used in comparing the forecast and verification data.
         comparison (class): how to compare the forecast and verification data.
         dim (str): Dimension over which metric was applied.
-        kwargs (dict): other information
+        \*\*kwargs : other information
 
     Returns:
        skill (`xarray` object): prediction skill with additional attrs.


### PR DESCRIPTION
# Description

Adds necessary typing for mypy-compliance

## To-Do List

## Type of change

<!-- Please delete options that are not relevant.-->

-   [x]  Breaking change (fix or feature that would cause existing functionality to not work as expected)

The breaking change is that the affected functions (with call signatures containing `*`) MUST now use keyword arguments to operate (entries can no longer be passed as positional arguments). I'm not sure how much of a breaking change this is for `climpred`, but if it is, I can mention that in the changelog.

-   [ ]  This change requires a documentation update

# How Has This Been Tested?

Testing on GitHub Workflows

## Checklist (while developing)

-   [ ]  CHANGELOG is updated with reference to this PR.

## References

https://github.com/python/mypy/issues/9091
