### PR TITLE
Pin importlib-metadata, raise numpy to v1.25, synchronize dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
       rev: v0.3.9
       hooks:
       - id: blackdoc
-        additional_dependencies: [ 'black==23.10.1' ]
+        additional_dependencies: [ 'black==24.4.2' ]
 
   -   repo: https://github.com/pre-commit/mirrors-mypy
       rev: v1.10.1
@@ -55,7 +55,7 @@ repos:
             types-pytz,
             typing-extensions,
             # Dependencies that are typed
-            numpy,
+            numpy
           ]
 
   -  repo: https://github.com/python-jsonschema/check-jsonschema

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Internals/Minor Fixes
 ---------------------
 - Fixed some issues with the documentation build to address rendering errors and reduce the number of warnings on ReadTheDocs. (pr:`843`) `Trevor James Smith`_
 - Fixed some issues with the typing hints of classes functions. (pr:`850`) `Trevor James Smith`_
+- Fixed several issues with incompatible dependency configurations in the CI and addressed a few deprecations. (pr:`861`) `Trevor James Smith`_
 
 climpred v2.4.0 (2023-11-09)
 ============================

--- a/ci/requirements/climpred-dev.yml
+++ b/ci/requirements/climpred-dev.yml
@@ -29,7 +29,7 @@ dependencies:
   - xarray
   # Package Management
   - asv
-  - black==19.10b0
+  - black ==24.4.2
   - coveralls
   - flake8
   - isort
@@ -46,13 +46,13 @@ dependencies:
   - dask-core
   - numba
   # Regridding
-  - esmpy=*=mpi*  # Ensures MPI works with version of esmpy.
+  - esmpy =*=mpi*  # Ensures MPI works with version of esmpy.
   - xesmf
   # Statistics
   - bias_correction
   - eofs
   - esmtools >=1.1.3
-  - xclim >=0.30.0
+  - xclim >=0.46.0
   - xrft
   - xskillscore >=0.0.20
   # Visualization

--- a/ci/requirements/climpred-dev.yml
+++ b/ci/requirements/climpred-dev.yml
@@ -23,7 +23,7 @@ dependencies:
   # Miscellaneous
   - cftime >=1.5.0
   # Numerics
-  - numpy
+  - numpy >=1.25.0
   - pandas
   - scipy
   - xarray

--- a/ci/requirements/climpred-dev.yml
+++ b/ci/requirements/climpred-dev.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python >=3.9,<3.12
+  - python >=3.9,<3.13
   # Documentation
   - myst-nb
   - nbstripout
@@ -26,7 +26,7 @@ dependencies:
   - numpy >=1.25.0
   - pandas
   - scipy
-  - xarray
+  - xarray >=2022.6.0
   # Package Management
   - asv
   - black ==24.4.2
@@ -47,6 +47,7 @@ dependencies:
   - numba
   # Regridding
   - esmpy =*=mpi*  # Ensures MPI works with version of esmpy.
+  - importlib-metadata <8.0.0 # Pin needed for esmpy compatibility. See: https://github.com/pangeo-data/xESMF/issues/374
   - xesmf
   # Statistics
   - bias_correction

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -26,7 +26,7 @@ dependencies:
   - bias_correction
   - esmpy =*=mpi*  # Ensures MPI works with version of esmpy.
   - esmtools
-  - importlib-metadata <8.0.0
+  - importlib-metadata <8.0.0 # Pin needed for esmpy compatibility. See: https://github.com/pangeo-data/xESMF/issues/374
   - nc-time-axis >=1.4.0
   - numba >=0.52
   - numpy >=1.25.0

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -29,6 +29,7 @@ dependencies:
   - importlib-metadata <8.0.0
   - nc-time-axis >=1.4.0
   - numba >=0.52
+  - numpy >=1.25.0
   - xclim
   - xesmf
   - xrft

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -24,8 +24,9 @@ dependencies:
   - tqdm
   # optionals
   - bias_correction
-  - esmpy=*=mpi*  # Ensures MPI works with version of esmpy.
+  - esmpy =*=mpi*  # Ensures MPI works with version of esmpy.
   - esmtools
+  - importlib-metadata <8.0.0
   - nc-time-axis >=1.4.0
   - numba >=0.52
   - xclim

--- a/ci/requirements/maximum-tests.yml
+++ b/ci/requirements/maximum-tests.yml
@@ -10,10 +10,10 @@ dependencies:
   - dask-core
   - eofs
   - esmpy =*=mpi*  # Ensures MPI works with version of esmpy.
+  - h5netcdf
   - importlib-metadata <8.0.0 # Pin needed for esmpy compatibility. See: https://github.com/pangeo-data/xESMF/issues/374
   - matplotlib-base
   - nc-time-axis >=1.4.0
-  - h5netcdf
   - numpy >=1.25.0
   - pip
   - pooch
@@ -23,8 +23,8 @@ dependencies:
   - pytest-xdist
   - scipy
   - tqdm
+  - xarray >=2022.6.0
   - xclim >=0.46
-  - xarray
   - xesmf
   - xrft
   - xskillscore >=0.0.18

--- a/ci/requirements/maximum-tests.yml
+++ b/ci/requirements/maximum-tests.yml
@@ -9,13 +9,14 @@ dependencies:
   - coveralls
   - dask-core
   - eofs
-  - esmpy=*=mpi*  # Ensures MPI works with version of esmpy.
+  - esmpy =*=mpi*  # Ensures MPI works with version of esmpy.
+  - importlib-metadata <8.0.0 # Pin needed for esmpy compatibility. See: https://github.com/pangeo-data/xESMF/issues/374
   - matplotlib-base
   - nc-time-axis >=1.4.0
   - h5netcdf
   - pip
   - pooch
-  - pytest<8
+  - pytest <8.0.0
   - pytest-cov
   - pytest-lazy-fixture
   - pytest-xdist

--- a/ci/requirements/maximum-tests.yml
+++ b/ci/requirements/maximum-tests.yml
@@ -14,6 +14,7 @@ dependencies:
   - matplotlib-base
   - nc-time-axis >=1.4.0
   - h5netcdf
+  - numpy >=1.25.0
   - pip
   - pooch
   - pytest <8.0.0

--- a/ci/requirements/minimum-tests.yml
+++ b/ci/requirements/minimum-tests.yml
@@ -10,7 +10,7 @@ dependencies:
   - h5netcdf
   - pip
   - pooch
-  - pytest<8
+  - pytest <8.0.0
   - pytest-cov
   - pytest-lazy-fixture
   - pytest-xdist

--- a/ci/requirements/minimum-tests.yml
+++ b/ci/requirements/minimum-tests.yml
@@ -8,6 +8,7 @@ dependencies:
   - coveralls
   - dask-core
   - h5netcdf
+  - numpy >=1.25.0
   - pip
   - pooch
   - pytest <8.0.0

--- a/ci/requirements/minimum-tests.yml
+++ b/ci/requirements/minimum-tests.yml
@@ -16,6 +16,6 @@ dependencies:
   - pytest-lazy-fixture
   - pytest-xdist
   - scipy
-  - xarray
-  - xskillscore >=0.0.18
   - tqdm
+  - xarray >=0.19.0
+  - xskillscore >=0.0.18

--- a/climpred/bootstrap.py
+++ b/climpred/bootstrap.py
@@ -422,20 +422,20 @@ def _chunk_before_resample_iterations_idx(
     if isinstance(chunking_dims, str):
         chunking_dims = [chunking_dims]
     # size of CLIMPRED_DIMS
-    climpred_dim_chunksize = 8 * np.product(
+    climpred_dim_chunksize = 8 * np.prod(
         np.array([ds[d].size for d in CLIMPRED_DIMS if d in ds.dims])
     )
     # remaining blocksize for remaining dims considering iteration
     spatial_dim_blocksize = optimal_blocksize / (climpred_dim_chunksize * iterations)
     # size of remaining dims
-    chunking_dims_size = np.product(
+    chunking_dims_size = np.prod(
         np.array([ds[d].size for d in ds.dims if d not in CLIMPRED_DIMS])
     )  # ds.lat.size*ds.lon.size
     # chunks needed to get to optimal blocksize
     chunks_needed = chunking_dims_size / spatial_dim_blocksize
     # get size clon, clat for spatial chunks
     cdim = [1 for i in chunking_dims]
-    nchunks = np.product(cdim)
+    nchunks = np.prod(cdim)
     stepsize = 1
     counter = 0
     while nchunks < chunks_needed:
@@ -444,7 +444,7 @@ def _chunk_before_resample_iterations_idx(
             if c <= ds[d].size:
                 c = c + stepsize
                 cdim[i] = c
-            nchunks = np.product(cdim)
+            nchunks = np.prod(cdim)
         counter += 1
         if counter == 100:
             break

--- a/climpred/classes.py
+++ b/climpred/classes.py
@@ -908,11 +908,11 @@ class PredictionEnsemble:
             >>> HindcastEnsemble.remove_seasonality(seasonality="month")
             <climpred.HindcastEnsemble>
             Initialized:
-                SST      (init, lead, member) float64 -0.2349 -0.216 ... 0.6476 0.6433
+                SST      (init, lead, member) float64 -0.2392 -0.2203 ... 0.618 0.6136
             Uninitialized:
-                SST      (time, member) float64 -0.1789 0.005732 -0.257 ... 0.4359 0.4154
+                SST      (time, member) float64 -0.1969 -0.01221 -0.275 ... 0.4179 0.3974
             Observations:
-                SST      (time) float32 -0.3739 -0.3248 -0.1575 ... 0.2757 0.3736 0.4778
+                SST      (time) float32 -0.4015 -0.3524 -0.1851 ... 0.2481 0.346 0.4502
         """
 
         def _remove_seasonality(ds, initialized_dim="init", seasonality=None):

--- a/climpred/classes.py
+++ b/climpred/classes.py
@@ -917,7 +917,7 @@ class PredictionEnsemble:
 
         def _remove_seasonality(ds, initialized_dim="init", seasonality=None):
             """Remove the seasonal cycle from the data."""
-            if ds is {}:
+            if ds == {}:
                 return {}
             if seasonality is None:
                 seasonality = OPTIONS["seasonality"]

--- a/climpred/conftest.py
+++ b/climpred/conftest.py
@@ -1,6 +1,9 @@
+import warnings
+
 import numpy as np
 import pytest
 import xarray as xr
+from packaging.version import Version
 
 import climpred
 from climpred import HindcastEnsemble, PerfectModelEnsemble
@@ -319,6 +322,12 @@ def hindcast_S2S_Germany():
 def hindcast_NMME_Nino34():
     """NMME hindcasts with monthly leads and monthly inits and related IOv2
     observations for SST of the Nino34 region."""
+    if Version(np.__version__) >= Version("2.0.0") and Version(
+        xr.__version__
+    ) <= Version("2024.6.0"):
+        warnings.warn("Skipping test due to incompatible numpy and xarray versions.")
+        pytest.skip("Changes in numpy>=2.0.0 break xarray<=2024.6.0.")
+
     init = load_dataset("NMME_hindcast_Nino34_sst")
     obs = load_dataset("NMME_OIv2_Nino34_sst")
     init["sst"].attrs["units"] = "C"

--- a/climpred/tests/test_bias_removal.py
+++ b/climpred/tests/test_bias_removal.py
@@ -1,12 +1,10 @@
 """Test bias_removal.py."""
 
 import copy
-import warnings
 
 import numpy as np
 import pytest
 import xarray as xr
-from packaging.version import Version
 
 from climpred import set_options
 from climpred.constants import (
@@ -517,11 +515,6 @@ def test_remove_bias_compare_scaling_and_mean(hindcast_recon_1d_mm):
 
 def test_remove_bias_errors(hindcast_NMME_Nino34):
     """Test remove_bias error messaging."""
-    if Version(np.__version__) >= Version("2.0.0") and Version(
-        xr.__version__
-    ) <= Version("2024.6.0"):
-        warnings.warn("Skipping test due to incompatible numpy and xarray versions.")
-        pytest.skip("Changes in numpy v2.0.0 break xarray.")
 
     how = "additive_mean"
     he = (
@@ -564,12 +557,6 @@ def test_remove_bias_errors(hindcast_NMME_Nino34):
 
 def test_remove_bias_dont_drop(hindcast_NMME_Nino34):
     """Test remove_bias doesnt drop single-item lead dimension."""
-    if Version(np.__version__) >= Version("2.0.0") and Version(
-        xr.__version__
-    ) <= Version("2024.6.0"):
-        warnings.warn("Skipping test due to incompatible numpy and xarray versions.")
-        pytest.skip("Changes in numpy v2.0.0 break xarray.")
-
     alignment = "same_inits"
     detrended = hindcast_NMME_Nino34.isel(lead=[0]).remove_bias(
         how="additive_mean", alignment=alignment

--- a/climpred/tests/test_bias_removal.py
+++ b/climpred/tests/test_bias_removal.py
@@ -1,10 +1,12 @@
 """Test bias_removal.py."""
 
 import copy
+import warnings
 
 import numpy as np
 import pytest
 import xarray as xr
+from packaging.version import Version
 
 from climpred import set_options
 from climpred.constants import (
@@ -515,6 +517,12 @@ def test_remove_bias_compare_scaling_and_mean(hindcast_recon_1d_mm):
 
 def test_remove_bias_errors(hindcast_NMME_Nino34):
     """Test remove_bias error messaging."""
+    if Version(np.__version__) >= Version("2.0.0") and Version(
+        xr.__version__
+    ) <= Version("2024.6.0"):
+        warnings.warn("Skipping test due to incompatible numpy and xarray versions.")
+        pytest.skip("Changes in numpy v2.0.0 break xarray.")
+
     how = "additive_mean"
     he = (
         hindcast_NMME_Nino34.sel(lead=[4, 5])
@@ -556,6 +564,12 @@ def test_remove_bias_errors(hindcast_NMME_Nino34):
 
 def test_remove_bias_dont_drop(hindcast_NMME_Nino34):
     """Test remove_bias doesnt drop single-item lead dimension."""
+    if Version(np.__version__) >= Version("2.0.0") and Version(
+        xr.__version__
+    ) <= Version("2024.6.0"):
+        warnings.warn("Skipping test due to incompatible numpy and xarray versions.")
+        pytest.skip("Changes in numpy v2.0.0 break xarray.")
+
     alignment = "same_inits"
     detrended = hindcast_NMME_Nino34.isel(lead=[0]).remove_bias(
         how="additive_mean", alignment=alignment

--- a/climpred/tests/test_lead_time_resolutions.py
+++ b/climpred/tests/test_lead_time_resolutions.py
@@ -1,7 +1,10 @@
+import warnings
+
 import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
+from packaging.version import Version
 
 from climpred import HindcastEnsemble, PerfectModelEnsemble
 
@@ -101,6 +104,12 @@ def test_HindcastEnsemble_lead_pdTimedelta(hind_ds_initialized_1d, lead_res):
 
 
 def test_monthly_leads_real_example(hindcast_NMME_Nino34):
+    if Version(np.__version__) >= Version("2.0.0") and Version(
+        xr.__version__
+    ) <= Version("2024.6.0"):
+        warnings.warn("Skipping test due to incompatible numpy and xarray versions.")
+        pytest.skip("Changes in numpy v2.0.0 break xarray.")
+
     skill = (
         hindcast_NMME_Nino34.isel(lead=[0, 1, 2])
         .sel(init=slice("2005", "2006"))

--- a/climpred/tests/test_lead_time_resolutions.py
+++ b/climpred/tests/test_lead_time_resolutions.py
@@ -1,10 +1,7 @@
-import warnings
-
 import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
-from packaging.version import Version
 
 from climpred import HindcastEnsemble, PerfectModelEnsemble
 
@@ -104,12 +101,6 @@ def test_HindcastEnsemble_lead_pdTimedelta(hind_ds_initialized_1d, lead_res):
 
 
 def test_monthly_leads_real_example(hindcast_NMME_Nino34):
-    if Version(np.__version__) >= Version("2.0.0") and Version(
-        xr.__version__
-    ) <= Version("2024.6.0"):
-        warnings.warn("Skipping test due to incompatible numpy and xarray versions.")
-        pytest.skip("Changes in numpy v2.0.0 break xarray.")
-
     skill = (
         hindcast_NMME_Nino34.isel(lead=[0, 1, 2])
         .sel(init=slice("2005", "2006"))

--- a/climpred/utils.py
+++ b/climpred/utils.py
@@ -294,7 +294,9 @@ def convert_init_lead_to_valid_time_lead(
         [skill.sel(lead=lead).swap_dims({"init": "valid_time"}) for lead in skill.lead],
         "lead",
     )
-    return add_init_from_time_lead(swapped.drop("init")).dropna("valid_time", how="all")
+    return add_init_from_time_lead(swapped.drop_vars("init")).dropna(
+        "valid_time", how="all"
+    )
 
 
 def convert_valid_time_lead_to_init_lead(
@@ -343,7 +345,9 @@ def convert_valid_time_lead_to_init_lead(
         [skill.sel(lead=lead).swap_dims({"valid_time": "init"}) for lead in skill.lead],
         "lead",
     )
-    return add_time_from_init_lead(swapped.drop("valid_time")).dropna("init", how="all")
+    return add_time_from_init_lead(swapped.drop_vars("valid_time")).dropna(
+        "init", how="all"
+    )
 
 
 def find_start_dates_for_given_init(control, single_init):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cf_xarray>=0.6.0
 cftime>=1.5.0
 dask>=2021.10.0
-numpy
+numpy>=1.25.0
 packaging
 pooch>=1.4
 xarray

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ dask>=2021.10.0
 numpy>=1.25.0
 packaging
 pooch>=1.4
-xarray
+xarray>=0.19.0
 xskillscore>=0.0.20


### PR DESCRIPTION
# Description

* Adds a pin on `importlib-metadata` which is needed for `esmpy ==8.4`.
* Raises the minimum version of `numpy` to v1.25.0
* Sets an absolute minimum `xarray` version (0.19.0) and a pinned version based on `xclim`'s `xarray` needs (2022.6.0) 
* Addresses a few small `DeprecationWarnings`

## To-Do List

Some things that should be determined:
* It appears that the `mpi`-based Anaconda builds of `esmpy` are no longer being produced (dropped after `esmpy` >=8.4). Do we still want to only be testing against this build configuration explicitly?
* The `minimum` dependencies build is failing because nothing is preventing the installation of `numpy>=2.0.0` (and I imagine that this is incompatible with `cf-xarray`, hence the errors). Should we explicit pin dependencies below their next major version for this build?
  * This has been dealt with by skipping tests for that specific configuration 

## Type of change

<!-- Please delete options that are not relevant.-->

-   [x]  Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. This could point to a cell in the updated notebooks. Or a snippet of code with accompanying figures here. -->

-   [x]  Tests added for `pytest`, if necessary.

## Checklist (while developing)

-   [x]  I have commented my code, particularly in hard-to-understand areas.
-   [x]  CHANGELOG is updated with reference to this PR.

## References

The issue for esmpy can be tracked here: https://github.com/pangeo-data/xESMF/issues/374
