### PR TITLE
Fix _maybe_auto_chunk to not rechunk dask arrays and no pearsonr climatology bootstrap

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ Internals/Minor Fixes
 - Updated `pre-commit` and GitHub CI hooks to more modern versions. (:pr:`866`, :pr:`867`) `Trevor James Smith`_
 - Updated several documentation and CI-related configurations to help with security hardening and maintainability. (:pr:`870`) `Trevor James Smith`_
 - Dependency updates to better synchronize `conda` and `pip` installation environments. (:pr:`870`) `Trevor James Smith`_
+- climatology reference forecast of pearon_r metric isn't tested to be non-NaN anymore (:pr:`884`) `Aaron Spring`_
 
 
 climpred v2.5.0 (2024-07-05)

--- a/src/climpred/bootstrap.py
+++ b/src/climpred/bootstrap.py
@@ -264,7 +264,7 @@ def resample_uninitialized_from_initialized(init, resample_dim=["init", "member"
         raise ValueError(
             "`resample_uninitialized_from_initialized` only works if the same number "
             " of initializations is present each year, found "
-            f'{init.init.dt.year.groupby("init.year").count()}.'
+            f"{init.init.dt.year.groupby('init.year').count()}."
         )
     if "init" not in resample_dim:
         raise ValueError(
@@ -388,7 +388,7 @@ def _maybe_auto_chunk(ds, dims):
 
     Args:
         ds (xr.Dataset): input data.
-        dims (list of str or str): Dimensions to auto-chunk in.
+        dims (list of str or str): Dimension(s) to auto-chunk in.
 
     Returns:
         xr.Dataset: auto-chunked along `dims`
@@ -397,9 +397,13 @@ def _maybe_auto_chunk(ds, dims):
     if dask.is_dask_collection(ds) and dims != []:
         if isinstance(dims, str):
             dims = [dims]
-        chunks = [d for d in dims if d in ds.dims]
-        chunks = {key: "auto" for key in chunks}
-        ds = ds.chunk(chunks)
+        chunks = {key: "auto" for key in dims if key in ds.dims}
+        if not chunks:
+            return ds
+        for name in ds.data_vars:
+            var = ds[name]
+            if not dask.is_dask_collection(var) and var.dtype != object:
+                ds[name] = var.chunk(chunks)
     return ds
 
 

--- a/src/climpred/tests/test_bootstrap.py
+++ b/src/climpred/tests/test_bootstrap.py
@@ -483,7 +483,7 @@ def test_resample_iterations_dix_no_squeeze(PM_ds_initialized_1d):
     assert "test_dim" in actual.dims
 
 
-@pytest.mark.parametrize("metric", ["acc", "mae"])
+@pytest.mark.parametrize("metric", ["rmse", "mae"])
 def test_bootstrap_p_climatology(hindcast_hist_obs_1d, metric):
     """Test that p from bootstrap is close to 0 if skillful."""
     reference = "climatology"

--- a/src/climpred/tests/test_bootstrap.py
+++ b/src/climpred/tests/test_bootstrap.py
@@ -47,7 +47,7 @@ xr.set_options(display_style="text")
     ],
     ids=["PerfectModelEnsemble", "HindcastEnsemble"],
 )
-@pytest.mark.parametrize("metric", ["pearson_r", "crps", "rmse"])
+@pytest.mark.parametrize("metric", ["crps", "rmse", "pearson_r"])
 @pytest.mark.parametrize("alignment", ["same_inits", "maximize", "same_verifs"])
 def test_bootstrap_resample_dim_init_all_skill_ci(initialized, metric, alignment):
     """Test that bootstrap with resample_dim='init' generates uncertainty in all skills."""
@@ -76,10 +76,15 @@ def test_bootstrap_resample_dim_init_all_skill_ci(initialized, metric, alignment
             initialized[[v]].isel(lead=slice(None, 3)).bootstrap(**kwargs)
     else:
         bskill = initialized[[v]].isel(lead=slice(None, 3)).bootstrap(**kwargs)
-        # expect iteration variance
-        assert (
-            bskill.sel(results=["high_ci", "low_ci"]).diff("results")[v].notnull().all()
-        )
+        ci_diff = bskill.sel(results=["high_ci", "low_ci"]).diff("results")[v]
+        if metric == "pearson_r":
+            assert (
+                ci_diff.sel(skill=["initialized", "persistence", "uninitialized"])
+                .notnull()
+                .all()
+            )
+        else:
+            assert ci_diff.notnull().all()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Goal: fix climpred errors from fix-xarray-v2025 branch

Avoid xarray bug with partial chunk dicts like {'iteration': 'auto'} by only chunking non-dask arrays and object-dtype variables.

non breaking change

should fix src/climpred/tests/test_bootstrap.py::test_bootstrap_PM_lazy_result

AND not test pearsonr for climatology bootstrap