### PR TITLE
faster tests

### DIFF
--- a/.github/workflows/climpred_testing.yml
+++ b/.github/workflows/climpred_testing.yml
@@ -60,7 +60,7 @@ jobs:
           python -c "import climpred; climpred.tutorial._cache_all()"
       - name: Run tests
         run: |
-          pytest -n 4 --durations=20
+          pytest -n auto --durations=20
 
   minimum-test-conda:  # Runs testing suite with minimal dependencies
     name: Test minimum dependencies (Python${{ matrix.python-version }}, conda)
@@ -101,7 +101,7 @@ jobs:
           python -c "import climpred; climpred.tutorial._cache_all()"
       - name: Run tests
         run: |
-          pytest -n 4 --durations=20
+          pytest -n auto --durations=20
 
   maximum-test-conda:  # Runs testing suite with all optional dependencies
     name: Test optional dependencies (Python${{ matrix.python-version }}, conda)
@@ -160,7 +160,7 @@ jobs:
           python -c "import climpred; climpred.tutorial._cache_all()"
       - name: Run tests
         run: |
-          pytest -n 4 --durations=20 --cov=climpred --cov-report=xml
+          pytest -n auto --durations=20 --cov=climpred --cov-report=xml
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de  # v5.5.2
         with:

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -178,7 +178,7 @@ Preparing Pull Requests
    Check that `doctests <https://docs.pytest.org/en/stable/doctest.html>`_ are
    passing::
 
-    $ pytest --doctest-modules climpred --ignore climpred/tests
+    $ pytest --doctest-modules src/climpred/classes.py --ignore src/climpred/tests
 
    Check that your contribution is covered by tests and therefore increases
    the overall test coverage::

--- a/src/climpred/conftest.py
+++ b/src/climpred/conftest.py
@@ -545,7 +545,3 @@ def small_verif_da():
     )
 
 
-@pytest.fixture(scope="session")
-def session_data_cache():
-    """Session-scoped cache for expensive data loading operations."""
-    return {}

--- a/src/climpred/conftest.py
+++ b/src/climpred/conftest.py
@@ -72,7 +72,7 @@ def PM_ds_initialized_3d_full():
 def PM_ds_initialized_3d(PM_ds_initialized_3d_full):
     """MPI Perfect-model-framework initialized maps xr.Dataset of subselected North
     Atlantic."""
-    return PM_ds_initialized_3d_full.sel(x=slice(120, 130), y=slice(50, 60))
+    return PM_ds_initialized_3d_full.sel(x=slice(120, 125), y=slice(50, 55))
 
 
 @pytest.fixture()
@@ -98,7 +98,7 @@ def PM_ds_control_3d_full():
 def PM_ds_control_3d(PM_ds_control_3d_full):
     """To MPI Perfect-model-framework corresponding control maps xr.Dataset of
     subselected North Atlantic."""
-    return PM_ds_control_3d_full.sel(x=slice(120, 130), y=slice(50, 60))
+    return PM_ds_control_3d_full.sel(x=slice(120, 125), y=slice(50, 55))
 
 
 @pytest.fixture()
@@ -165,7 +165,7 @@ def hind_ds_initialized_3d_full():
 @pytest.fixture()
 def hind_ds_initialized_3d(hind_ds_initialized_3d_full):
     """CESM-DPLE initialized hindcast Pacific maps mean removed xr.Dataset."""
-    return hind_ds_initialized_3d_full.isel(nlon=slice(0, 10), nlat=slice(0, 12))
+    return hind_ds_initialized_3d_full.isel(nlon=slice(0, 5), nlat=slice(0, 5))
 
 
 @pytest.fixture()
@@ -210,7 +210,7 @@ def reconstruction_ds_3d_full():
 def reconstruction_ds_3d(reconstruction_ds_3d_full):
     """CESM-FOSI historical reconstruction maps members mean removed
     xr.Dataset."""
-    return reconstruction_ds_3d_full.isel(nlon=slice(0, 10), nlat=slice(0, 12))
+    return reconstruction_ds_3d_full.isel(nlon=slice(0, 5), nlat=slice(0, 5))
 
 
 @pytest.fixture()
@@ -326,12 +326,6 @@ def hindcast_S2S_Germany():
 def hindcast_NMME_Nino34():
     """NMME hindcasts with monthly leads and monthly inits and related IOv2
     observations for SST of the Nino34 region."""
-    if Version(np.__version__) >= Version("2.0.0") and Version(
-        xr.__version__
-    ) <= Version("2024.6.0"):
-        warnings.warn("Skipping test due to incompatible numpy and xarray versions.")
-        pytest.skip("Changes in numpy>=2.0.0 break xarray<=2024.6.0.")
-
     init = load_dataset("NMME_hindcast_Nino34_sst")
     obs = load_dataset("NMME_OIv2_Nino34_sst")
     init["sst"].attrs["units"] = "C"
@@ -552,3 +546,9 @@ def small_verif_da():
     return xr.DataArray(
         np.random.rand(len(time)), dims=["time"], coords=[time], name="var"
     )
+
+
+@pytest.fixture(scope="session")
+def session_data_cache():
+    """Session-scoped cache for expensive data loading operations."""
+    return {}

--- a/src/climpred/conftest.py
+++ b/src/climpred/conftest.py
@@ -1,9 +1,6 @@
-import warnings
-
 import numpy as np
 import pytest
 import xarray as xr
-from packaging.version import Version
 
 import climpred
 from climpred import HindcastEnsemble, PerfectModelEnsemble

--- a/src/climpred/conftest.py
+++ b/src/climpred/conftest.py
@@ -165,7 +165,7 @@ def hind_ds_initialized_3d_full():
 @pytest.fixture()
 def hind_ds_initialized_3d(hind_ds_initialized_3d_full):
     """CESM-DPLE initialized hindcast Pacific maps mean removed xr.Dataset."""
-    return hind_ds_initialized_3d_full.isel(nlon=slice(0, 5), nlat=slice(0, 5))
+    return hind_ds_initialized_3d_full.isel(nlon=slice(0, 10), nlat=slice(0, 12))
 
 
 @pytest.fixture()
@@ -210,7 +210,7 @@ def reconstruction_ds_3d_full():
 def reconstruction_ds_3d(reconstruction_ds_3d_full):
     """CESM-FOSI historical reconstruction maps members mean removed
     xr.Dataset."""
-    return reconstruction_ds_3d_full.isel(nlon=slice(0, 5), nlat=slice(0, 5))
+    return reconstruction_ds_3d_full.isel(nlon=slice(0, 10), nlat=slice(0, 12))
 
 
 @pytest.fixture()

--- a/src/climpred/conftest.py
+++ b/src/climpred/conftest.py
@@ -543,5 +543,3 @@ def small_verif_da():
     return xr.DataArray(
         np.random.rand(len(time)), dims=["time"], coords=[time], name="var"
     )
-
-

--- a/src/climpred/tests/__init__.py
+++ b/src/climpred/tests/__init__.py
@@ -11,6 +11,10 @@ def _importorskip(modname, minversion=None):
         if minversion is not None:
             if version.parse(mod.__version__) < version.parse(minversion):
                 raise ImportError("Minimum version not satisfied")
+            if modname == "matplotlib":
+                import matplotlib
+
+                matplotlib.use("Agg")
     except ImportError:
         has = False
     func = pytest.mark.skipif(not has, reason=f"requires {modname}")

--- a/src/climpred/tests/test_graphics.py
+++ b/src/climpred/tests/test_graphics.py
@@ -79,6 +79,8 @@ def test_PredictionEnsemble_plot(
 ):
     """Test PredictionEnsemble.plot()."""
     he = HindcastEnsemble(hind_ds_initialized_1d)
+    kws = {"show_members": show_members, "variable": variable, "x": x}
+    he.plot(**kws)
     he = he.add_uninitialized(hist_ds_uninitialized_1d)
     kws = {"show_members": show_members, "variable": variable, "x": x}
     he.plot(**kws)

--- a/src/climpred/tests/test_graphics.py
+++ b/src/climpred/tests/test_graphics.py
@@ -86,7 +86,7 @@ def test_PredictionEnsemble_plot(
     he = he.add_observations(reconstruction_ds_1d)
     he.plot(**kws)
     he = he.add_observations(observations_ds_1d)
-    he.plot()
+    he.plot(**kws)
 
     if x == "time":
         pm = PerfectModelEnsemble(hind_ds_initialized_1d)

--- a/src/climpred/tests/test_graphics.py
+++ b/src/climpred/tests/test_graphics.py
@@ -8,7 +8,7 @@ from climpred.graphics import plot_bootstrapped_skill_over_leadyear
 
 from . import requires_matplotlib, requires_nc_time_axis
 
-ITERATIONS = 100
+ITERATIONS = 200
 
 
 @pytest.fixture(autouse=True)

--- a/src/climpred/tests/test_graphics.py
+++ b/src/climpred/tests/test_graphics.py
@@ -8,7 +8,7 @@ from climpred.graphics import plot_bootstrapped_skill_over_leadyear
 
 from . import requires_matplotlib, requires_nc_time_axis
 
-ITERATIONS = 10
+ITERATIONS = 25
 
 
 @pytest.fixture(autouse=True)

--- a/src/climpred/tests/test_graphics.py
+++ b/src/climpred/tests/test_graphics.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from climpred import PerfectModelEnsemble, HindcastEnsemble
+from climpred import HindcastEnsemble, PerfectModelEnsemble
 from climpred.checks import DimensionError
 from climpred.graphics import plot_bootstrapped_skill_over_leadyear
 
@@ -42,7 +42,9 @@ def test_PerfectModelEnsemble_plot_bootstrapped_skill_over_leadyear(
 @pytest.mark.parametrize("cmap", ["tab10", "jet"])
 @pytest.mark.parametrize("show_members", [True, False])
 @pytest.mark.parametrize("variable", ["tos", None])
-def test_PerfectModelEnsemble_plot(PM_ds_initialized_1d, PM_ds_control_1d, variable, show_members, cmap):
+def test_PerfectModelEnsemble_plot(
+    PM_ds_initialized_1d, PM_ds_control_1d, variable, show_members, cmap
+):
     """Test PredictionEnsemble.plot()."""
     pm = PerfectModelEnsemble(PM_ds_initialized_1d)
     kws = {"cmap": cmap, "show_members": show_members, "variable": variable}
@@ -94,9 +96,7 @@ def test_PredictionEnsemble_plot(
 @requires_nc_time_axis
 @pytest.mark.parametrize("alignment", ["same_inits", None])
 @pytest.mark.parametrize("return_xr", [False, True])
-def test_HindcastEnsemble_plot_alignment(
-    hindcast_hist_obs_1d, alignment, return_xr
-):
+def test_HindcastEnsemble_plot_alignment(hindcast_hist_obs_1d, alignment, return_xr):
     """Test HindcastEnsemble.plot_alignment()"""
     import matplotlib
     import xarray as xr

--- a/src/climpred/tests/test_graphics.py
+++ b/src/climpred/tests/test_graphics.py
@@ -87,6 +87,7 @@ def test_PredictionEnsemble_plot(
     he = he.add_observations(reconstruction_ds_1d)
     he.plot(**kws)
     he = he.add_observations(observations_ds_1d)
+    he.plot()
 
     if x == "time":
         pm = PerfectModelEnsemble(hind_ds_initialized_1d)

--- a/src/climpred/tests/test_graphics.py
+++ b/src/climpred/tests/test_graphics.py
@@ -1,5 +1,7 @@
 """Test graphics.py and PredictionEnsemble.plot()."""
 
+# Set matplotlib to non-interactive backend for testing to avoid resource leaks
+import matplotlib
 import numpy as np
 import pytest
 import xarray as xr
@@ -9,9 +11,6 @@ from climpred.checks import DimensionError
 from climpred.graphics import plot_bootstrapped_skill_over_leadyear
 
 from . import requires_matplotlib, requires_nc_time_axis
-
-# Set matplotlib to non-interactive backend for testing to avoid resource leaks
-import matplotlib
 
 matplotlib.use("Agg")
 
@@ -72,7 +71,11 @@ def test_PerfectModelEnsemble_plot_fails_3d(synthetic_pm_3d_small):
 @pytest.mark.parametrize("show_members", [True, False])
 @pytest.mark.parametrize("variable", ["SST", None])
 def test_PredictionEnsemble_plot(
-    synthetic_hindcast_1d_small, synthetic_uninitialized_1d_small, variable, show_members, x
+    synthetic_hindcast_1d_small,
+    synthetic_uninitialized_1d_small,
+    variable,
+    show_members,
+    x,
 ):
     """Test PredictionEnsemble.plot()."""
     he = synthetic_hindcast_1d_small

--- a/src/climpred/tests/test_graphics.py
+++ b/src/climpred/tests/test_graphics.py
@@ -8,7 +8,7 @@ from climpred.graphics import plot_bootstrapped_skill_over_leadyear
 
 from . import requires_matplotlib, requires_nc_time_axis
 
-ITERATIONS = 3
+ITERATIONS = 10
 
 
 @pytest.fixture(autouse=True)
@@ -29,7 +29,7 @@ def test_PerfectModelEnsemble_plot_bootstrapped_skill_over_leadyear(
     """
     res = perfectModelEnsemble_initialized_control.bootstrap(
         metric="pearson_r",
-        iterations=ITERATIONS * 20,
+        iterations=ITERATIONS,
         reference=["uninitialized", "persistence"],
         comparison="m2e",
         dim=["init", "member"],

--- a/src/climpred/tests/test_graphics.py
+++ b/src/climpred/tests/test_graphics.py
@@ -1,19 +1,12 @@
 """Test graphics.py and PredictionEnsemble.plot()."""
 
-import numpy as np
 import pytest
-import xarray as xr
 
-from climpred import HindcastEnsemble, PerfectModelEnsemble
+from climpred import PerfectModelEnsemble
 from climpred.checks import DimensionError
 from climpred.graphics import plot_bootstrapped_skill_over_leadyear
 
 from . import requires_matplotlib, requires_nc_time_axis
-
-# Set matplotlib to non-interactive backend for testing to avoid resource leaks
-import matplotlib
-
-matplotlib.use("Agg")
 
 ITERATIONS = 3
 
@@ -72,7 +65,11 @@ def test_PerfectModelEnsemble_plot_fails_3d(synthetic_pm_3d_small):
 @pytest.mark.parametrize("show_members", [True, False])
 @pytest.mark.parametrize("variable", ["SST", None])
 def test_PredictionEnsemble_plot(
-    synthetic_hindcast_1d_small, synthetic_uninitialized_1d_small, variable, show_members, x
+    synthetic_hindcast_1d_small,
+    synthetic_uninitialized_1d_small,
+    variable,
+    show_members,
+    x,
 ):
     """Test PredictionEnsemble.plot()."""
     he = synthetic_hindcast_1d_small

--- a/src/climpred/tests/test_graphics.py
+++ b/src/climpred/tests/test_graphics.py
@@ -80,6 +80,7 @@ def test_PredictionEnsemble_plot(
     """Test PredictionEnsemble.plot()."""
     he = HindcastEnsemble(hind_ds_initialized_1d)
     he = he.add_uninitialized(hist_ds_uninitialized_1d)
+    kws = {"show_members": show_members, "variable": variable, "x": x}
     he.plot(**kws)
     he = he.add_observations(reconstruction_ds_1d)
     he.plot(**kws)

--- a/src/climpred/tests/test_graphics.py
+++ b/src/climpred/tests/test_graphics.py
@@ -58,7 +58,7 @@ def test_PerfectModelEnsemble_plot(
 @requires_matplotlib
 def test_PerfectModelEnsemble_plot_fails_3d(PM_ds_initialized_3d):
     """Test PredictionEnsemble.plot()."""
-    pm = PM_ds_initialized_3d
+    pm = PerfectModelEnsemble(PM_ds_initialized_3d)
     with pytest.raises(DimensionError) as excinfo:
         pm.plot()
     assert "does not allow dimensions other" in str(excinfo.value)

--- a/src/climpred/tests/test_graphics.py
+++ b/src/climpred/tests/test_graphics.py
@@ -8,7 +8,7 @@ from climpred.graphics import plot_bootstrapped_skill_over_leadyear
 
 from . import requires_matplotlib, requires_nc_time_axis
 
-ITERATIONS = 25
+ITERATIONS = 100
 
 
 @pytest.fixture(autouse=True)

--- a/src/climpred/tests/test_graphics.py
+++ b/src/climpred/tests/test_graphics.py
@@ -82,7 +82,6 @@ def test_PredictionEnsemble_plot(
     kws = {"show_members": show_members, "variable": variable, "x": x}
     he.plot(**kws)
     he = he.add_uninitialized(hist_ds_uninitialized_1d)
-    kws = {"show_members": show_members, "variable": variable, "x": x}
     he.plot(**kws)
     he = he.add_observations(reconstruction_ds_1d)
     he.plot(**kws)

--- a/src/climpred/tutorial.py
+++ b/src/climpred/tutorial.py
@@ -99,7 +99,7 @@ def _get_datasets():
 
 
 def _cache_all():
-    """Cache all datasets for pytest -n 4 woth pytest-xdist."""
+    """Cache all datasets for pytest -n auto woth pytest-xdist."""
     for d in aliases:
         load_dataset(d)
 


### PR DESCRIPTION
# Description

30min CI is too long

starting against: https://github.com/pangeo-data/climpred/actions/workflows/climpred_testing.yml?query=branch%3Aupdates-2025+is%3Asuccess 21-35min

optimising: https://github.com/pangeo-data/climpred/actions/workflows/climpred_testing.yml?query=branch%3Amanually_reduce_tests+is%3Asuccess

Closes #877 

## To-Do List

- [x] `pytest -n auto`
- [x] ~~session-based~~ see https://github.com/pangeo-data/climpred/pull/891
- [x] rm skipped test for version 
- [x] ~~synthetic data~~ reverted

## Type of change

-   [x]  Refactoring