### PR TITLE
Replace mypy with ty type checker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,21 +49,15 @@ repos:
         additional_dependencies: [ 'black==25.1.0' ]
       - id: blackdoc-autoupdate-black
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.17.0
+  - repo: local
     hooks:
-      - id: mypy
+      - id: ty
+        name: ty (type checker)
+        entry: ty check
+        language: system
+        types: [python]
         exclude: 'asv_bench'
-        additional_dependencies: [
-          # Type stubs
-          types-PyYAML,
-          types-python-dateutil,
-          types-pytz,
-          types-setuptools,
-          typing-extensions,
-          # Dependencies that are typed
-          numpy
-        ]
+        pass_filenames: false
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.33.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,10 +54,11 @@ repos:
       - id: ty
         name: ty (type checker)
         entry: ty check
-        language: system
+        language: python
         types: [python]
         exclude: 'asv_bench'
         pass_filenames: false
+        additional_dependencies: ['ty>=0.0.1a14']
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.33.2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,7 @@ Internals/Minor Fixes
 - `pytest-lazy-fixture` (abandoned) has been replaced by `pytest-lazy-fixtures` (maintained fork).
 - GitHub Workflows have been adjusted to test against Python 3.13, as well as test `pip`-based environments. `Trevor James Smith`_
 - Replaced all `assert` statements found outside of the testing code with appropriate exceptions to be handled. `Trevor James Smith`_
+- Use `ty` instead of `mypy` (:issue:`888`, :pr:`896`) `Aaron Spring`_
 
 climpred v2.5.0 (2024-07-05)
 ============================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,9 +13,9 @@ dev = [
   "flake8",
   "isort",
   "jupyterlab",
-  "mypy >=1.13",
   "pylint",
-  "pytest-sugar"
+  "pytest-sugar",
+  "ty >=0.0.1a14"
 ]
 docs = [
   "climpred[docs]"
@@ -105,31 +105,6 @@ skip = [
   "docs/source/conf.py"
 ]
 
-[tool.mypy]
-exclude = "asv_bench|doc"
-files = "."
-show_error_codes = true
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = [
-  "bottleneck.*",
-  "cftime.*",
-  "dask.*",
-  "distributed.*",
-  "fsspec.*",
-  "matplotlib.*",
-  "nc_time_axis.*",
-  "numpy.*",
-  "netCDF4.*",
-  "pandas.*",
-  "pytest.*",
-  "scipy.*",
-  "setuptools",
-  "toolz.*"
-]
-ignore_missing_imports = true
-
 [tool.pytest.ini_options]
 python_files = ["test_*.py"]
 addopts = [
@@ -179,3 +154,29 @@ description = {file = "src/climpred/__init__.py"}
 fallback_version = "999"
 version_scheme = "post-release"
 local_scheme = "dirty-tag"
+
+[tool.ty.analysis]
+allowed-unresolved-imports = [
+  "bottleneck.**",
+  "cftime.**",
+  "dask.**",
+  "distributed.**",
+  "fsspec.**",
+  "matplotlib.**",
+  "nc_time_axis.**",
+  "numpy.**",
+  "netCDF4.**",
+  "pandas.**",
+  "pytest.**",
+  "scipy.**",
+  "setuptools.**",
+  "toolz.**",
+  "xarray.**",
+  "xskillscore.**",
+  "pooch.**",
+  "cf_xarray.**",
+  "packaging.**"
+]
+
+[tool.ty.src]
+exclude = ["asv_bench/", "docs/"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,7 +196,6 @@ allowed-unresolved-imports = [
 possibly-missing-attribute = "ignore"
 invalid-assignment = "ignore"
 invalid-argument-type = "ignore"
-unsupported-operator = "ignore"
 missing-argument = "ignore"
 unknown-argument = "ignore"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,7 +195,6 @@ allowed-unresolved-imports = [
 # These can be gradually enabled as types are added
 possibly-missing-attribute = "ignore"
 invalid-assignment = "ignore"
-not-subscriptable = "ignore"
 invalid-argument-type = "ignore"
 unsupported-operator = "ignore"
 missing-argument = "ignore"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,8 +191,8 @@ allowed-unresolved-imports = [
 ]
 
 [tool.ty.rules]
-# Ignore rules that produce too many false positives for this codebase
-# These can be gradually enabled as the codebase gets better type annotations
+# Ignore rules until the codebase has better type annotations
+# These can be gradually enabled as types are added
 possibly-missing-attribute = "ignore"
 invalid-assignment = "ignore"
 not-subscriptable = "ignore"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,7 +200,6 @@ invalid-argument-type = "ignore"
 unsupported-operator = "ignore"
 missing-argument = "ignore"
 unknown-argument = "ignore"
-unused-ignore-comment = "ignore"
 
 [tool.ty.src]
 exclude = ["asv_bench/", "docs/"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,26 +157,51 @@ local_scheme = "dirty-tag"
 
 [tool.ty.analysis]
 allowed-unresolved-imports = [
+  "bias_correction.**",
   "bottleneck.**",
+  "cf_xarray.**",
   "cftime.**",
   "dask.**",
   "distributed.**",
+  "eofs.**",
   "fsspec.**",
+  "intake.**",
+  "intake_esm.**",
   "matplotlib.**",
   "nc_time_axis.**",
-  "numpy.**",
   "netCDF4.**",
+  "numba.**",
+  "numpy.**",
+  "packaging.**",
   "pandas.**",
+  "pooch.**",
+  "properscoring.**",
   "pytest.**",
+  "pytest_lazy_fixtures.**",
   "scipy.**",
   "setuptools.**",
   "toolz.**",
+  "tqdm.**",
   "xarray.**",
-  "xskillscore.**",
-  "pooch.**",
-  "cf_xarray.**",
-  "packaging.**"
+  "xclim.**",
+  "xesmf.**",
+  "xrft.**",
+  "xsdba.**",
+  "xskillscore.**"
 ]
+
+[tool.ty.rules]
+# Ignore rules that produce too many false positives for this codebase
+# These can be gradually enabled as the codebase gets better type annotations
+possibly-missing-attribute = "ignore"
+invalid-assignment = "ignore"
+not-subscriptable = "ignore"
+invalid-argument-type = "ignore"
+unsupported-operator = "ignore"
+missing-argument = "ignore"
+unknown-argument = "ignore"
+unused-ignore-comment = "ignore"
+deprecated = "ignore"
 
 [tool.ty.src]
 exclude = ["asv_bench/", "docs/"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,7 +193,6 @@ allowed-unresolved-imports = [
 [tool.ty.rules]
 # Ignore rules until the codebase has better type annotations
 # These can be gradually enabled as types are added
-possibly-missing-attribute = "ignore"
 invalid-assignment = "ignore"
 invalid-argument-type = "ignore"
 missing-argument = "ignore"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,7 +201,6 @@ unsupported-operator = "ignore"
 missing-argument = "ignore"
 unknown-argument = "ignore"
 unused-ignore-comment = "ignore"
-deprecated = "ignore"
 
 [tool.ty.src]
 exclude = ["asv_bench/", "docs/"]

--- a/src/climpred/alignment.py
+++ b/src/climpred/alignment.py
@@ -22,27 +22,27 @@ def _isin(
     if isinstance(init_lead_matrix, xr.DataArray):
         if init_lead_matrix.time.size < 100:  # previous behavior for few inits
             return init_lead_matrix.isin(all_verifs)
+        init_lead_da = init_lead_matrix
+    else:
+        raise TypeError("init_lead_matrix must be a DataArray")
+
     if not isinstance(all_verifs, xr.CFTimeIndex):
         all_verifs = all_verifs.to_index()
-    if len(init_lead_matrix.dims) == 2:
+    if len(init_lead_da.dims) == 2:
         init_lead_asi8 = np.vstack(
-            [
-                init_lead_matrix.sel(lead=i).to_index().asi8
-                for i in init_lead_matrix.lead
-            ]
+            [init_lead_da.sel(lead=i).to_index().asi8 for i in init_lead_da.lead]
         )
         isin = np.isin(init_lead_asi8, all_verifs.asi8)
-    elif len(init_lead_matrix.dims) == 1:
-        if not isinstance(init_lead_matrix, xr.CFTimeIndex):
-            init_lead_matrix2 = init_lead_matrix.to_index()
-        else:
-            init_lead_matrix2 = init_lead_matrix
-        isin = np.isin(init_lead_matrix2.asi8, all_verifs.asi8)
+    elif len(init_lead_da.dims) == 1:
+        init_lead_da_idx: xr.CFTimeIndex = init_lead_da.to_index()
+        isin = np.isin(init_lead_da_idx.asi8, all_verifs.asi8)
+    else:
+        raise ValueError("init_lead_matrix must have 1 or 2 dimensions")
     return xr.DataArray(
         data=isin,
-        dims=init_lead_matrix.dims,
-        coords=init_lead_matrix.coords,
-        attrs=init_lead_matrix.attrs,
+        dims=init_lead_da.dims,
+        coords=init_lead_da.coords,
+        attrs=init_lead_da.attrs,
     )
 
 

--- a/src/climpred/alignment.py
+++ b/src/climpred/alignment.py
@@ -169,7 +169,7 @@ def _same_inits_alignment(
     inits = {lead: inits for lead in leads}
     verif_dates = {
         lead: shift_cftime_index(inits[lead], "time", n, freq)
-        for (lead, n) in zip(leads, n)  # type: ignore
+        for (lead, n) in zip(leads, n)
     }
     return inits, verif_dates
 

--- a/src/climpred/bias_removal.py
+++ b/src/climpred/bias_removal.py
@@ -490,7 +490,10 @@ def bias_correction(
                 train_dim = shift_cftime_singular(train_dim[dim], n, freq)
                 data_to_be_corrected = forecast.drop_sel({dim: train_dim})
             elif alignment in ["same_verif"]:
-                assert train_time is not None
+                if train_time is None:
+                    raise ValueError(
+                        "train_time must be provided for alignment='same_verif'"
+                    )
                 train_dim = train_time
                 intersection = (
                     train_dim[dim].to_index().intersection(forecast[dim].to_index())
@@ -668,7 +671,10 @@ def xclim_sdba(
                 train_dim = shift_cftime_singular(train_dim[dim], n, freq)
                 data_to_be_corrected = forecast.drop_sel({dim: train_dim})
             elif alignment in ["same_verif"]:
-                assert train_time is not None
+                if train_time is None:
+                    raise ValueError(
+                        "train_time must be provided for alignment='same_verif'"
+                    )
                 train_dim = train_time
                 intersection = (
                     train_dim[dim].to_index().intersection(forecast[dim].to_index())
@@ -696,9 +702,9 @@ def xclim_sdba(
             data_to_be_corrected = leave_one_out(data_to_be_corrected, dim)
 
         if "group" not in metric_kwargs:
-            metric_kwargs["group"] = dim + "." + str(OPTIONS["seasonality"])
+            metric_kwargs["group"] = f"{dim}.{OPTIONS['seasonality']}"
         elif metric_kwargs["group"] is None:
-            metric_kwargs["group"] = dim + "." + str(OPTIONS["seasonality"])
+            metric_kwargs["group"] = f"{dim}.{OPTIONS['seasonality']}"
 
         if "init" in metric_kwargs["group"]:
             metric_kwargs["group"] = metric_kwargs["group"].replace("init", "time")

--- a/src/climpred/bias_removal.py
+++ b/src/climpred/bias_removal.py
@@ -490,6 +490,7 @@ def bias_correction(
                 train_dim = shift_cftime_singular(train_dim[dim], n, freq)
                 data_to_be_corrected = forecast.drop_sel({dim: train_dim})
             elif alignment in ["same_verif"]:
+                assert train_time is not None
                 train_dim = train_time
                 intersection = (
                     train_dim[dim].to_index().intersection(forecast[dim].to_index())
@@ -667,6 +668,7 @@ def xclim_sdba(
                 train_dim = shift_cftime_singular(train_dim[dim], n, freq)
                 data_to_be_corrected = forecast.drop_sel({dim: train_dim})
             elif alignment in ["same_verif"]:
+                assert train_time is not None
                 train_dim = train_time
                 intersection = (
                     train_dim[dim].to_index().intersection(forecast[dim].to_index())

--- a/src/climpred/bias_removal.py
+++ b/src/climpred/bias_removal.py
@@ -696,9 +696,9 @@ def xclim_sdba(
             data_to_be_corrected = leave_one_out(data_to_be_corrected, dim)
 
         if "group" not in metric_kwargs:
-            metric_kwargs["group"] = dim + "." + OPTIONS["seasonality"]
+            metric_kwargs["group"] = dim + "." + str(OPTIONS["seasonality"])
         elif metric_kwargs["group"] is None:
-            metric_kwargs["group"] = dim + "." + OPTIONS["seasonality"]
+            metric_kwargs["group"] = dim + "." + str(OPTIONS["seasonality"])
 
         if "init" in metric_kwargs["group"]:
             metric_kwargs["group"] = metric_kwargs["group"].replace("init", "time")

--- a/src/climpred/bootstrap.py
+++ b/src/climpred/bootstrap.py
@@ -30,7 +30,7 @@ from .stats import dpp
 try:
     from .stats import varweighted_mean_period
 except ImportError:
-    varweighted_mean_period = None  # type: ignore
+    varweighted_mean_period = None
 from .utils import (
     _transpose_and_rechunk_to,
     find_start_dates_for_given_init,

--- a/src/climpred/classes.py
+++ b/src/climpred/classes.py
@@ -221,7 +221,9 @@ class PredictionEnsemble:
         skill_group = xr.concat(
             skill_group, dim=new_dim_name, **CONCAT_KWARGS
         ).assign_coords({new_dim_name: group_label})
-        skill_group[new_dim_name] = skill_group[new_dim_name].assign_attrs(  # type: ignore # noqa: E501
+        skill_group[new_dim_name] = skill_group[
+            new_dim_name
+        ].assign_attrs(  # noqa: E501
             {
                 "description": "new dimension showing skill grouped by init.{groupby}"
                 " created by .verify(groupby) or .bootstrap(groupby)"
@@ -547,7 +549,9 @@ class PredictionEnsemble:
             )
         # catch other dimensions in other
         if isinstance(other, tuple([xr.Dataset, xr.DataArray])):
-            if not set(other.dims).issubset(self._datasets["initialized"].dims):  # type: ignore # noqa: E501
+            if not set(other.dims).issubset(
+                self._datasets["initialized"].dims
+            ):  # noqa: E501
                 raise DimensionError(f"{error_str} containing new dimensions.")
         # catch xr.Dataset with different data_vars
         if isinstance(other, xr.Dataset):

--- a/src/climpred/classes.py
+++ b/src/climpred/classes.py
@@ -207,11 +207,12 @@ class PredictionEnsemble:
 
     def _groupby(self, call: str, groupby: Union[str, xr.DataArray], **kwargs: Any):
         """Help for verify/bootstrap(groupby="month")."""
-        skill_group, group_label = [], []
+        skill_group_list: List[Any] = []
+        group_label: List[Any] = []
         groupby_str = f"init.{groupby}" if isinstance(groupby, str) else groupby
         with set_options(warn_for_failed_PredictionEnsemble_xr_call=False):
             for group, hind_group in self.get_initialized().init.groupby(groupby_str):
-                skill_group.append(
+                skill_group_list.append(
                     getattr(self.sel(init=hind_group), call)(
                         **kwargs,
                     )
@@ -219,7 +220,7 @@ class PredictionEnsemble:
                 group_label.append(group)
         new_dim_name = groupby if isinstance(groupby, str) else groupby.name
         skill_group = xr.concat(
-            skill_group, dim=new_dim_name, **CONCAT_KWARGS
+            skill_group_list, dim=new_dim_name, **CONCAT_KWARGS
         ).assign_coords({new_dim_name: group_label})
         skill_group[new_dim_name] = skill_group[
             new_dim_name
@@ -758,11 +759,11 @@ class PredictionEnsemble:
 
     def get_initialized(self) -> xr.Dataset:
         """Return the :py:class:`xarray.Dataset` for the initialized ensemble."""
-        return self._datasets["initialized"]
+        return self._datasets["initialized"]  # type: ignore
 
     def get_uninitialized(self) -> xr.Dataset:
         """Return the :py:class:`xarray.Dataset` for the uninitialized ensemble."""
-        return self._datasets["uninitialized"]
+        return self._datasets["uninitialized"]  # type: ignore
 
     def smooth(
         self,
@@ -1354,7 +1355,7 @@ class PerfectModelEnsemble(PredictionEnsemble):
 
     def get_control(self) -> xr.Dataset:
         """Return the control as an :py:class:`xarray.Dataset`."""
-        return self._datasets["control"]
+        return self._datasets["control"]  # type: ignore
 
     def verify(
         self,
@@ -1963,7 +1964,7 @@ class HindcastEnsemble(PredictionEnsemble):
         Returns:
             observations
         """
-        return self._datasets["observations"]
+        return self._datasets["observations"]  # type: ignore
 
     def generate_uninitialized(
         self, resample_dim: List[str] = ["init", "member"]

--- a/src/climpred/classes.py
+++ b/src/climpred/classes.py
@@ -493,11 +493,13 @@ class PredictionEnsemble:
                 self, variable=variable, ax=ax, show_members=show_members, cmap=cmap
             )
 
-    mathType = Union[int, float, np.ndarray, xr.DataArray, xr.Dataset]
+    mathType = Union[
+        int, float, np.ndarray, xr.DataArray, xr.Dataset, "PredictionEnsemble"
+    ]
 
     def _math(
         self,
-        other: mathType,
+        other: "mathType",
         operator: str,
     ):
         """Help function for __add__, __sub__, __mul__, __truediv__.

--- a/src/climpred/metrics.py
+++ b/src/climpred/metrics.py
@@ -38,6 +38,7 @@ from .constants import CLIMPRED_DIMS
 
 dimType = Optional[Union[str, List[str]]]
 metric_kwargsType = Any
+metricReturnType = Union[xr.Dataset, xr.DataArray]
 
 
 def _get_norm_factor(comparison: Any) -> int:  # Comparison instead of Any
@@ -293,7 +294,7 @@ def _pearson_r(
     verif: xr.Dataset,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     r"""Pearson product-moment correlation coefficient.
 
     A measure of the linear association between the forecast and verification data that
@@ -383,7 +384,7 @@ def _pearson_r_p_value(
     verif: xr.Dataset,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     """Probability that forecast and verification data are linearly uncorrelated.
 
     Two-tailed p value associated with the Pearson product-moment correlation
@@ -466,7 +467,7 @@ def _effective_sample_size(
     verif: xr.Dataset,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     r"""Effective sample size for temporally correlated data.
 
     .. note::
@@ -560,7 +561,7 @@ def _pearson_r_eff_p_value(
     verif: xr.Dataset,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     r"""pearson_r_p_value accounting for autocorrelation.
 
     .. note::
@@ -668,7 +669,7 @@ def _spearman_r(
     verif: xr.Dataset,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     r"""Spearman's rank correlation coefficient.
 
     .. math::
@@ -761,7 +762,7 @@ def _spearman_r_p_value(
     verif: xr.Dataset,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     r"""Probability that forecast and verification data are monotonically uncorrelated.
 
     Two-tailed p value associated with the Spearman's rank correlation
@@ -844,7 +845,7 @@ def _spearman_r_eff_p_value(
     verif: xr.Dataset,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     r"""_spearman_r_p_value accounting for autocorrelation.
 
     .. note::
@@ -955,7 +956,7 @@ def _mse(
     verif: xr.Dataset,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     r"""Mean Sqaure Error (MSE).
 
     .. math::
@@ -1034,7 +1035,7 @@ def _me(
     verif: xr.Dataset,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     r"""Mean Error (ME).
 
     .. math::
@@ -1106,7 +1107,7 @@ def _spread(
     verif: xr.Dataset,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     r"""Ensemble spread taking the standard deviation over the member dimension.
 
     .. math::
@@ -1176,7 +1177,7 @@ def _rmse(
     verif: xr.Dataset,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     r"""Root Mean Sqaure Error (RMSE).
 
     .. math::
@@ -1248,7 +1249,7 @@ def _mae(
     verif: xr.Dataset,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     r"""Mean Absolute Error (MAE).
 
     .. math::
@@ -1324,7 +1325,7 @@ def _median_absolute_error(
     verif: xr.Dataset,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     """Median Absolute Error.
 
     .. math::
@@ -1402,7 +1403,7 @@ def _nmse(
     verif: xr.Dataset,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     r"""Compte Normalized MSE (NMSE), also known as Normalized Ensemble Variance (NEV).
 
     Mean Square Error (``mse``) normalized by the variance of the verification data.
@@ -1504,7 +1505,7 @@ def _nmae(
     verif: xr.Dataset,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     r"""Compute Normalized Mean Absolute Error (NMAE).
 
     Mean Absolute Error (``mae``) normalized by the standard deviation of the
@@ -1607,7 +1608,7 @@ def _nrmse(
     verif: xr.Dataset,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     r"""Compute Normalized Root Mean Square Error (NRMSE).
 
     Root Mean Square Error (``rmse``) normalized by the standard deviation of the
@@ -1713,7 +1714,7 @@ def _msess(
     verif: xr.Dataset,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     r"""Mean Squared Error Skill Score (MSESS).
 
     .. math::
@@ -1821,7 +1822,7 @@ def _mape(
     verif: xr.Dataset,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     r"""Mean Absolute Percentage Error (MAPE).
 
     Mean absolute error (``mae``) expressed as the fractional error relative to the
@@ -1893,7 +1894,7 @@ def _smape(
     verif: xr.Dataset,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     r"""Symmetric Mean Absolute Percentage Error (sMAPE).
 
     Similar to the Mean Absolute Percentage Error (``mape``), but sums the forecast and
@@ -1965,7 +1966,7 @@ def _uacc(
     verif: xr.Dataset,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     r"""Bushuk's unbiased Anomaly Correlation Coefficient (uACC).
 
     This is typically used in perfect model studies. Because the perfect model Anomaly
@@ -2067,7 +2068,7 @@ def _std_ratio(
     verif: xr.Dataset,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     r"""Ratio of standard deviations of the forecast over the verification data.
 
     .. math:: \text{std ratio} = \frac{\sigma_f}{\sigma_o},
@@ -2141,7 +2142,7 @@ def _unconditional_bias(
     verif: xr.Dataset,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     r"""Unconditional additive bias.
 
     .. math::
@@ -2243,7 +2244,7 @@ def _mul_bias(
     verif: xr.Dataset,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     r"""
     Multiplicative bias.
 
@@ -2314,7 +2315,7 @@ def _conditional_bias(
     verif: xr.Dataset,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     r"""Conditional bias between forecast and verification data.
 
     .. math::
@@ -2392,7 +2393,7 @@ def _bias_slope(
     verif: xr.Dataset,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     r"""Bias slope between verification data and forecast standard deviations.
 
     .. math::
@@ -2472,7 +2473,7 @@ def _msess_murphy(
     verif: xr.Dataset,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     r"""Murphy's Mean Square Error Skill Score (MSESS).
 
     .. math::
@@ -2570,7 +2571,7 @@ def _brier_score(
     verif: xr.Dataset,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     """Brier Score for binary events.
 
     The Mean Square Error (``mse``) of probabilistic two-category forecasts where the
@@ -2746,7 +2747,7 @@ def _threshold_brier_score(
     verif: xr.Dataset,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     r"""Brier score of an ensemble for exceeding given thresholds.
 
     .. math::
@@ -2873,7 +2874,7 @@ def _crps(
     verif: xr.Dataset,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     r"""Continuous Ranked Probability Score (CRPS).
 
     The CRPS can also be considered as the probabilistic Mean Absolute Error (``mae``).
@@ -2968,7 +2969,7 @@ def _crps_quadrature(
     cdf_or_dist: Callable,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     """Compute the continuously ranked probability score (CPRS).
 
     For a given
@@ -2997,7 +2998,7 @@ def _crpss(
     verif: xr.Dataset,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     r"""Continuous Ranked Probability Skill Score.
 
     This can be used to assess whether the ensemble spread is a useful measure for the
@@ -3091,7 +3092,10 @@ def _crpss(
     """
     if dim is None:
         dim = list(verif.dims)
-    if isinstance(dim, str):
+    elif isinstance(dim, str):
+        dim = [dim]
+    # At this point dim should be a list
+    if not isinstance(dim, list):
         dim = list(dim)
     # available climpred dimensions to take mean and std over
     rdim = [tdim for tdim in verif.dims if tdim in CLIMPRED_DIMS]
@@ -3142,7 +3146,7 @@ def _crpss_es(
     verif: xr.Dataset,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     r"""Continuous Ranked Probability Skill Score Ensemble Spread.
 
     If the ensemble variance is smaller than the observed ``mse``, the ensemble is
@@ -3206,12 +3210,16 @@ def _crpss_es(
 
     """
     if dim is None:
-        dim = verif.dims
+        dim_list = verif.dims
+    elif isinstance(dim, str):
+        dim_list = [dim]
+    else:
+        dim_list = dim
     # helper dim to calc mu
     rdim = [d for d in verif.dims if d in CLIMPRED_DIMS]
     mu = verif.mean(rdim)
     # forecast, verif_member = xr.broadcast(forecast, verif)
-    dim_no_member = [d for d in dim if d != "member"]
+    dim_no_member = [d for d in dim_list if d != "member"]
     ensemble_spread = forecast.std("member").mean(dim=dim_no_member, **metric_kwargs)
     if forecast.member.size == 1:
         warnings.warn(
@@ -3248,7 +3256,7 @@ def _discrimination(
     verif: xr.Dataset,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     """
     Discrimination.
 
@@ -3412,7 +3420,7 @@ def _reliability(
     verif: xr.Dataset,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     """
     Reliability.
 
@@ -3574,7 +3582,7 @@ def _rank_histogram(
     verif: xr.Dataset,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     """Rank histogram or Talagrand diagram.
 
     Args:
@@ -3665,7 +3673,7 @@ def _rps(
     verif: xr.Dataset,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     r"""Ranked Probability Score.
 
     .. math::
@@ -3967,7 +3975,7 @@ def _roc(
     verif: xr.Dataset,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     """Receiver Operating Characteristic.
 
     Args:
@@ -4097,7 +4105,7 @@ def _less(
     verif: xr.Dataset,
     dim: dimType = None,
     **metric_kwargs: metric_kwargsType,
-) -> xr.Dataset:
+) -> metricReturnType:
     r"""
     Logarithmic Ensemble Spread Score.
 

--- a/src/climpred/prediction.py
+++ b/src/climpred/prediction.py
@@ -68,6 +68,8 @@ def _apply_metric_at_given_lead(
     """
     # naming:: lforecast: forecast at lead; lverif: verification at lead
     if reference is None:
+        assert initialized is not None
+        assert inits is not None
         # Use `.where()` instead of `.sel()` to account for resampled inits when
         # bootstrapping.
         lforecast = initialized.sel(lead=lead).where(

--- a/src/climpred/prediction.py
+++ b/src/climpred/prediction.py
@@ -68,8 +68,10 @@ def _apply_metric_at_given_lead(
     """
     # naming:: lforecast: forecast at lead; lverif: verification at lead
     if reference is None:
-        assert initialized is not None
-        assert inits is not None
+        if initialized is None:
+            raise ValueError("initialized must be provided when reference is None")
+        if inits is None:
+            raise ValueError("inits must be provided when reference is None")
         # Use `.where()` instead of `.sel()` to account for resampled inits when
         # bootstrapping.
         lforecast = initialized.sel(lead=lead).where(

--- a/src/climpred/preprocessing/mpi.py
+++ b/src/climpred/preprocessing/mpi.py
@@ -35,7 +35,7 @@ def get_path(
     experiment_id = [x for x in dirs if (f"{init}" in x and f"r{member}i" in x)]
     if len(experiment_id) != 1:
         raise ValueError("Multiple experiment ids found.")
-    experiment_id = experiment_id[0]  # type: ignore
+    experiment_id = experiment_id[0]
     dir_outdata = f"{dir_base_experiment}/{experiment_id}/outdata/{model}"
     path = f"{dir_outdata}/{experiment_id}_{model}_{output_stream}_{timestr}.{ending}"
     if _os.path.exists(_glob.glob(path)[0]):

--- a/src/climpred/preprocessing/shared.py
+++ b/src/climpred/preprocessing/shared.py
@@ -112,7 +112,9 @@ def rename_to_climpred_dims(
         renamed = False  # set renamed flag to false initiallly
         if cdim not in xro.dims:  # if a CLIMPRED_ENSEMBLE_DIMS is not found
             for c in xro.dims:  # check in xro.dims for dims
-                if cdim in c:  # containing the string of this CLIMPRED_ENSEMBLE_DIMS
+                if cdim in str(
+                    c
+                ):  # containing the string of this CLIMPRED_ENSEMBLE_DIMS
                     xro = xro.rename({c: cdim})
                     renamed = True
         # special case for hindcast when containing time

--- a/src/climpred/reference.py
+++ b/src/climpred/reference.py
@@ -118,7 +118,7 @@ def climatology(
             .sel(
                 {
                     seasonality_str: _maybe_seasons_to_int(
-                        getattr(verif_hind_union.time.dt, seasonality_str)  # type: ignore
+                        getattr(verif_hind_union.time.dt, seasonality_str)
                     )
                 },
                 method="nearest",  # nearest may be a bit incorrect but doesnt error
@@ -510,7 +510,7 @@ def compute_persistence_from_first_lead(
         comparison = COMPARISON_ALIASES.get(comparison, comparison)
         comparison = get_comparison_class(comparison, ALL_COMPARISONS)
 
-    forecast, observations = comparison.function(initialized, metric=metric)  # type: ignore
+    forecast, observations = comparison.function(initialized, metric=metric)
     forecast, dim = _adapt_member_for_reference_forecast(
         forecast, observations, metric, comparison, dim
     )

--- a/src/climpred/smoothing.py
+++ b/src/climpred/smoothing.py
@@ -264,6 +264,6 @@ def smooth_goddard_2013(
     # first temporal smoothing
     ds_smoothed = temporal_smoothing(ds, tsmooth_kws=tsmooth_kws)
     ds_smoothed_regridded = spatial_smoothing_xesmf(
-        ds_smoothed, d_lon_lat_kws=d_lon_lat_kws, **xesmf_kwargs  # type: ignore
+        ds_smoothed, d_lon_lat_kws=d_lon_lat_kws, **xesmf_kwargs
     )
     return ds_smoothed_regridded

--- a/src/climpred/tests/test_graphics.py
+++ b/src/climpred/tests/test_graphics.py
@@ -8,6 +8,9 @@ from climpred.graphics import plot_bootstrapped_skill_over_leadyear
 
 from . import requires_matplotlib, requires_nc_time_axis
 
+# ss
+
+
 ITERATIONS = 3
 
 
@@ -20,7 +23,7 @@ def test_PerfectModelEnsemble_plot_bootstrapped_skill_over_leadyear(
     """
     res = perfectModelEnsemble_initialized_control.bootstrap(
         metric="pearson_r",
-        iterations=ITERATIONS * 100,
+        iterations=ITERATIONS * 20,
         reference=["uninitialized", "persistence"],
         comparison="m2e",
         dim=["init", "member"],

--- a/src/climpred/tests/test_graphics.py
+++ b/src/climpred/tests/test_graphics.py
@@ -20,7 +20,7 @@ def test_PerfectModelEnsemble_plot_bootstrapped_skill_over_leadyear(
     """
     res = perfectModelEnsemble_initialized_control.bootstrap(
         metric="pearson_r",
-        iterations=ITERATIONS * 20,
+        iterations=ITERATIONS,
         reference=["uninitialized", "persistence"],
         comparison="m2e",
         dim=["init", "member"],

--- a/src/climpred/tests/test_graphics.py
+++ b/src/climpred/tests/test_graphics.py
@@ -8,10 +8,7 @@ from climpred.graphics import plot_bootstrapped_skill_over_leadyear
 
 from . import requires_matplotlib, requires_nc_time_axis
 
-# ss
-
-
-ITERATIONS = 3
+ITERATIONS = 300
 
 
 @requires_matplotlib

--- a/src/climpred/utils.py
+++ b/src/climpred/utils.py
@@ -110,10 +110,14 @@ def assign_attrs(
         skill.attrs["dim"] = dim
     if reference is not None:
         skill.attrs["reference"] = reference
-    if "persistence" in reference and "PerfectModelEnsemble" in function_name:
-        skill.attrs["PerfectModel_persistence_from_initialized_lead_0"] = OPTIONS[
-            "PerfectModel_persistence_from_initialized_lead_0"
-        ]
+        if (
+            "persistence" in reference
+            and function_name
+            and "PerfectModelEnsemble" in function_name
+        ):
+            skill.attrs["PerfectModel_persistence_from_initialized_lead_0"] = OPTIONS[
+                "PerfectModel_persistence_from_initialized_lead_0"
+            ]
 
     # change unit power in all variables
     if metric.unit_power == 0:

--- a/src/climpred/versioning/print_versions.py
+++ b/src/climpred/versioning/print_versions.py
@@ -1,7 +1,6 @@
 """utility functions for printing version information
 see pandas/pandas/util/_print_versions.py"""
 
-import codecs
 import importlib
 import locale
 import os
@@ -113,7 +112,7 @@ def show_versions(as_json=False):
         if as_json is True:
             print(j)
         else:
-            with codecs.open(as_json, "wb", encoding="utf8") as f:
+            with open(as_json, "w", encoding="utf8") as f:
                 json.dump(j, f, indent=2)
 
     else:


### PR DESCRIPTION
## Summary
Replace mypy with [ty](https://github.com/astral-sh/ty), a faster type checker from the same team as ruff/uv.

## Changes
- Replace `mypy >=1.13` with `ty >=0.0.1a14` in dev dependencies
- Replace `[tool.mypy]` config with `[tool.ty]` config in pyproject.toml
- Use local pre-commit hook for ty (no official pre-commit repo yet, tracked in astral-sh/ty#269)

## Why ty?
- Much faster than mypy (written in Rust, like ruff)
- From the same team as ruff/uv (Astral)
- Drop-in replacement for mypy

From
- previously 13s https://results.pre-commit.ci/run/github/103773583/1769621040.DB_C686kSI-cL8Nvxs9BAA
- to this PR 8s https://results.pre-commit.ci/run/github/103773583/1769619929.ta2Wt2_2TVWbUgz3aB85Pg

Closes #888