### PR TITLE
Reduce xarray and cftime warnings

### DIFF
--- a/src/climpred/classes.py
+++ b/src/climpred/classes.py
@@ -2112,6 +2112,7 @@ class HindcastEnsemble(PredictionEnsemble):
             xr.concat(
                 alignment_dates,
                 "alignment",
+                join="outer",
             )
             .assign_coords(alignment=alignments_success)
             .squeeze()

--- a/src/climpred/classes.py
+++ b/src/climpred/classes.py
@@ -2903,7 +2903,7 @@ class HindcastEnsemble(PredictionEnsemble):
             ).issubset(set(self.get_initialized().dims)):
                 self._datasets["initialized"].coords["valid_time"] = (
                     add_time_from_init_lead(
-                        self.get_initialized().drop("valid_time")
+                        self.get_initialized().drop_vars("valid_time")
                     ).coords["valid_time"]
                 )
         return self

--- a/src/climpred/conftest.py
+++ b/src/climpred/conftest.py
@@ -594,11 +594,12 @@ def perfectModelEnsemble_initialized_control_1d_ym_cftime(
 @pytest.fixture(scope="session")
 def _PM_ds_initialized_1d_mm_cftime(_PM_ds_initialized_1d):
     ds = _PM_ds_initialized_1d.copy(deep=True)
-    ds["init"] = xr.cftime_range(
+    ds["init"] = xr.date_range(
         start="3004",
         periods=ds.init.size,
         freq="MS",
         calendar=CALENDAR,
+        use_cftime=True,
     )
     return ds.load()
 
@@ -615,8 +616,12 @@ def PM_ds_initialized_1d_mm_cftime(_PM_ds_initialized_1d_mm_cftime):
 @pytest.fixture(scope="session")
 def _PM_ds_control_1d_mm_cftime(_PM_ds_control_1d):
     ds = _PM_ds_control_1d.copy(deep=True)
-    ds["time"] = xr.cftime_range(
-        start="3000", periods=ds.time.size, freq="MS", calendar=CALENDAR
+    ds["time"] = xr.date_range(
+        start="3000",
+        periods=ds.time.size,
+        freq="MS",
+        calendar=CALENDAR,
+        use_cftime=True,
     )
     return ds.load()
 
@@ -642,11 +647,12 @@ def perfectModelEnsemble_initialized_control_1d_mm_cftime(
 @pytest.fixture(scope="session")
 def _PM_ds_initialized_1d_dm_cftime(_PM_ds_initialized_1d):
     ds = _PM_ds_initialized_1d.copy(deep=True)
-    ds["init"] = xr.cftime_range(
+    ds["init"] = xr.date_range(
         start="3004",
         periods=ds.init.size,
         freq="D",
         calendar=CALENDAR,
+        use_cftime=True,
     )
     return ds.load()
 
@@ -665,8 +671,8 @@ def _PM_ds_control_1d_dm_cftime(_PM_ds_control_1d):
     ds = _PM_ds_control_1d.copy(deep=True)
     # session scope randomization is fine here as it's just for testing coverage
     ds = ds.isel(time=np.random.randint(0, ds.time.size, 5000))
-    ds["time"] = xr.cftime_range(
-        start="3000", periods=ds.time.size, freq="D", calendar=CALENDAR
+    ds["time"] = xr.date_range(
+        start="3000", periods=ds.time.size, freq="D", calendar=CALENDAR, use_cftime=True
     )
     return ds.load()
 

--- a/src/climpred/constants.py
+++ b/src/climpred/constants.py
@@ -24,7 +24,7 @@ HINDCAST_CALENDAR_STR = "DatetimeProlepticGregorian"
 
 # default kwargs when using concat
 # data_vars='minimal' could be added but needs to check that xr.Dataset
-CONCAT_KWARGS = {"coords": "minimal", "compat": "override"}
+CONCAT_KWARGS = {"coords": "minimal", "compat": "override", "join": "outer"}
 
 # name for additional dimension in m2m comparison
 M2M_MEMBER_DIM = "forecast_member"

--- a/src/climpred/graphics.py
+++ b/src/climpred/graphics.py
@@ -438,5 +438,6 @@ def _verif_dates_xr(hindcast, alignment, reference, date2num_units):
             for k, v in inits.items()
         ],
         dim="lead",
+        join="outer",
     ).assign_coords(lead=hindcast.get_initialized().lead)
     return verif_dates_xr

--- a/src/climpred/reference.py
+++ b/src/climpred/reference.py
@@ -100,7 +100,7 @@ def climatology(
     if seasonality_str == "weekofyear":
         # convert to datetime for weekofyear operations
         verif = convert_cftime_to_datetime_coords(verif, "time")
-        init_lead["time"] = (init_lead["time"].to_index().to_datetimeindex())
+        init_lead["time"] = init_lead["time"].to_index().to_datetimeindex()
         init_lead = init_lead["time"]
     climatology_day = verif.groupby(f"time.{seasonality_str}").mean()
     with (

--- a/src/climpred/reference.py
+++ b/src/climpred/reference.py
@@ -100,7 +100,9 @@ def climatology(
     if seasonality_str == "weekofyear":
         # convert to datetime for weekofyear operations
         verif = convert_cftime_to_datetime_coords(verif, "time")
-        init_lead["time"] = init_lead["time"].to_index().to_datetimeindex()
+        init_lead["time"] = (
+            init_lead["time"].to_index().to_datetimeindex(time_unit="ns")
+        )
         init_lead = init_lead["time"]
     climatology_day = verif.groupby(f"time.{seasonality_str}").mean()
     with (

--- a/src/climpred/reference.py
+++ b/src/climpred/reference.py
@@ -100,9 +100,7 @@ def climatology(
     if seasonality_str == "weekofyear":
         # convert to datetime for weekofyear operations
         verif = convert_cftime_to_datetime_coords(verif, "time")
-        init_lead["time"] = (
-            init_lead["time"].to_index().to_datetimeindex(time_unit="ns")
-        )
+        init_lead["time"] = (init_lead["time"].to_index().to_datetimeindex())
         init_lead = init_lead["time"]
     climatology_day = verif.groupby(f"time.{seasonality_str}").mean()
     with (

--- a/src/climpred/tests/test_lead_time_resolutions.py
+++ b/src/climpred/tests/test_lead_time_resolutions.py
@@ -36,7 +36,7 @@ def HindcastEnsemble_time_resolution(request):
     elif request.param == "weeks":
         freq = "7D"
     elif request.param == "minutes":
-        freq = "T"
+        freq = "min"
     elif request.param in "months":
         freq = "MS"
     elif request.param == "seasons":
@@ -45,8 +45,12 @@ def HindcastEnsemble_time_resolution(request):
         freq = "YS"
     else:
         freq = request.param[0].upper()
+        if freq == "H":
+            freq = "h"
+        elif freq == "S":
+            freq = "s"
     # create initialized
-    init = xr.cftime_range(START, freq=freq, periods=NINITS)
+    init = xr.date_range(START, freq=freq, periods=NINITS, use_cftime=True)
     lead = np.arange(NLEADS)
     member = np.arange(NMEMBERS)
     initialized = xr.DataArray(
@@ -57,7 +61,7 @@ def HindcastEnsemble_time_resolution(request):
     initialized.lead.attrs["units"] = request.param
 
     # create observations
-    time = xr.cftime_range(START, freq=freq, periods=NINITS + NLEADS)
+    time = xr.date_range(START, freq=freq, periods=NINITS + NLEADS, use_cftime=True)
     obs = xr.DataArray(
         np.random.rand(len(time)), dims=["time"], coords=[time]
     ).to_dataset(name="var")

--- a/src/climpred/tests/test_utils.py
+++ b/src/climpred/tests/test_utils.py
@@ -127,7 +127,7 @@ def test_HindcastEnsemble_bootstrap_attrs(hindcast_hist_obs_1d, metric):
 
 def test_cftime_index_unchanged():
     """Tests that a CFTime index going through convert time is unchanged."""
-    inits = xr.cftime_range("1990", "2000", freq="Y", calendar="noleap")
+    inits = xr.date_range("1990", "2000", freq="YE", calendar="noleap", use_cftime=True)
     da = xr.DataArray(np.random.rand(len(inits)), dims="init", coords=[inits])
     new_inits = convert_time_index(da, "init", "")
     assert_allclose(new_inits.init, da.init)
@@ -207,7 +207,7 @@ def test_shift_cftime_singular():
 
 def test_shift_cftime_index():
     """Tests that ``CFTimeIndex`` is shifted by the appropriate amount."""
-    idx = xr.cftime_range("1990", "2000", freq="YS")
+    idx = xr.date_range("1990", "2000", freq="YS", use_cftime=True)
     da = xr.DataArray(np.random.rand(len(idx)), dims="time", coords=[idx])
     expected = idx.shift(3, "YS")
     res = shift_cftime_index(da, "time", 3, "YS")

--- a/src/climpred/tests/test_valid_time.py
+++ b/src/climpred/tests/test_valid_time.py
@@ -8,14 +8,14 @@ from climpred import HindcastEnsemble
 @pytest.mark.parametrize(
     "init_freq,lead_unit",
     [
-        ("AS-JUL", "years"),
-        ("AS-JUL", "months"),
-        ("AS-JUL", "seasons"),
+        ("YS-JUL", "years"),
+        ("YS-JUL", "months"),
+        ("YS-JUL", "seasons"),
         ("MS", "months"),
-        ("3M", "days"),
+        ("3ME", "days"),
         ("7D", "days"),
         ("1D", "hours"),
-        ("1H", "seconds"),
+        ("1h", "seconds"),
     ],
 )
 @pytest.mark.parametrize("calendar", ["ProlepticGregorian", "standard", "360_day"])
@@ -26,7 +26,7 @@ def test_hindcastEnsemble_init_time(init_freq, lead_unit, calendar):
     nlead = 2
     lead = [0, 1]
 
-    init = xr.cftime_range(start="2000", freq=init_freq, periods=p)
+    init = xr.date_range(start="2000", freq=init_freq, periods=p, use_cftime=True)
     data = np.random.rand(p, nlead)
     init = xr.DataArray(
         data,
@@ -94,7 +94,7 @@ def test_valid_time_from_larger_than_monthly_init_longer_freq_lead(
     start, freq, units, expected_shift
 ):
     """Raised in https://github.com/pangeo-data/climpred/issues/698"""
-    init = xr.cftime_range(start=start, end="2002-01-01", freq=freq)
+    init = xr.date_range(start=start, end="2002-01-01", freq=freq, use_cftime=True)
     print("init", init)
 
     lead = range(0, 5)

--- a/src/climpred/tutorial.py
+++ b/src/climpred/tutorial.py
@@ -204,6 +204,8 @@ def load_dataset(
             """
             raise IOError(msg)
 
+    kws.update({"decode_timedelta": True})
+
     ds = _open_dataset(localfile, **kws)
 
     if not cache:

--- a/src/climpred/utils.py
+++ b/src/climpred/utils.py
@@ -228,11 +228,7 @@ def convert_time_index(
 def convert_cftime_to_datetime_coords(ds, dim):
     """Convert dimension coordinate dim from CFTimeIndex to pd.DatetimeIndex."""
     return ds.assign_coords(
-        {
-            dim: xr.DataArray(
-                ds[dim].to_index().to_datetimeindex(time_unit="ns"), dims=dim
-            )
-        }
+        {dim: xr.DataArray(ds[dim].to_index().to_datetimeindex(), dims=dim)}
     )
 
 

--- a/src/climpred/utils.py
+++ b/src/climpred/utils.py
@@ -228,7 +228,11 @@ def convert_time_index(
 def convert_cftime_to_datetime_coords(ds, dim):
     """Convert dimension coordinate dim from CFTimeIndex to pd.DatetimeIndex."""
     return ds.assign_coords(
-        {dim: xr.DataArray(ds[dim].to_index().to_datetimeindex(), dims=dim)}
+        {
+            dim: xr.DataArray(
+                ds[dim].to_index().to_datetimeindex(time_unit="ns"), dims=dim
+            )
+        }
     )
 
 

--- a/src/climpred/utils.py
+++ b/src/climpred/utils.py
@@ -296,6 +296,8 @@ def convert_init_lead_to_valid_time_lead(
         [skill.sel(lead=lead).swap_dims({"init": "valid_time"}) for lead in skill.lead],
         "lead",
         join="outer",
+        coords="different",
+        compat="equals",
     )
     return add_init_from_time_lead(swapped.drop_vars("init")).dropna(
         "valid_time", how="all"
@@ -350,6 +352,9 @@ def convert_valid_time_lead_to_init_lead(
     swapped = xr.concat(
         [skill.sel(lead=lead).swap_dims({"valid_time": "init"}) for lead in skill.lead],
         "lead",
+        coords="different",
+        compat="equals",
+        join="outer",
     )
     return add_time_from_init_lead(swapped.drop_vars("valid_time")).dropna(
         "init", how="all"


### PR DESCRIPTION
### Description
This PR reduces several `xarray` and `cftime` warnings across the codebase and tests. It also improves test execution speed by ensuring compatibility with `pytest-xdist`.

### Changes
- **Core Improvements**:
  - Set `join="outer"` in `CONCAT_KWARGS` (`src/climpred/constants.py`) and specific `xr.concat` calls to avoid the upcoming change in `xarray` default behavior.
- **Warning Fixes**:
  - Replaced deprecated `xr.cftime_range` with `xr.date_range(..., use_cftime=True)`.
  - Updated deprecated frequency strings to their new counterparts:
    - `Y` -> `YE` (Year End)
    - `AS` -> `YS` (Year Start)
    - `M` -> `ME` (Month End)
    - `H` -> `h` (Hour)
    - `T` -> `min` (Minute)
- **Testing**:
  - Verified that tests run successfully and faster using `pytest -n auto`.

### To-Do
- [x] Run full test suite with `pytest -n auto`
- [x] Verify reduction in warnings

Close #897