### PR TITLE
Add publications using climpred (2022-2026)

### DIFF
--- a/docs/source/climpred.bib
+++ b/docs/source/climpred.bib
@@ -759,3 +759,66 @@
   issn = {0894-8755, 1520-0442},
   doi = {10/f88pgm},
 }
+
+@article{Zhao2024,
+  title = {Explainable El Ni{\~n}o predictability from climate mode interactions},
+  author = {Zhao, Sen and Jin, Fei-Fei and Stuecker, Malte F. and Thompson, Philip R. and Kug, Jong-Seong and McPhaden, Michael J. and Cane, Mark A. and Wittenberg, Andrew T. and Cai, Wenju},
+  year = {2024},
+  month = jun,
+  journal = {Nature},
+  volume = {630},
+  pages = {891--898},
+  doi = {10.1038/s41586-024-07534-6},
+}
+
+@article{Higgins2024,
+  title = {Subseasonal potential predictability of horizontal water vapor transport and precipitation extremes in the North Pacific},
+  author = {Higgins, Timothy B. and Subramanian, Aneesh C.},
+  year = {2024},
+  month = dec,
+  journal = {Weather and Forecasting},
+  volume = {39},
+  number = {6},
+  pages = {1077--1095},
+  doi = {10.1175/WAF-D-23-0170.1},
+}
+
+@article{Lesinger2025,
+  title = {Skillful subseasonal soil moisture drought forecasts with deep learning-dynamic models},
+  author = {Lesinger, Kristen and Tian, Di},
+  year = {2025},
+  month = jan,
+  journal = {Nature Communications},
+  volume = {16},
+  pages = {62761},
+  doi = {10.1038/s41467-025-62761-3},
+}
+
+@article{Schroers2026,
+  title = {Verification of Atmospheric Variables in S2S Project Models during Extended Extreme Precipitation Events},
+  author = {Schroers, Melanie A. and Martin, Elinor},
+  year = {2026},
+  journal = {Weather and Forecasting},
+  volume = {41},
+  number = {1},
+  pages = {3--21},
+  doi = {10.1175/WAF-D-24-0237.1},
+}
+
+@article{Mangolte2025,
+  title = {Investigating the predictability of Marine Heatwaves at subseasonal to seasonal timescales in New Caledonia, South Pacific},
+  author = {Mangolte, In{\`e}s and Cravatte, Sophie and Ganachaud, Alexandre and Menk{\`e}s, Christophe},
+  year = {2025},
+  journal = {EGUsphere},
+  doi = {10.5194/egusphere-2025-5995},
+}
+
+@article{Arsenault2023,
+  title = {The PAVICS-Hydro platform: A virtual laboratory for hydroclimatic modelling and forecasting over North America},
+  author = {Arsenault, Richard and Huard, David and Martel, Jean-Luc and Troin, Magali and Mai, Juliane and Brissette, Fran{\c c}ois and Jauvin, Christian and Vu, Long and Craig, James R. and Smith, Trevor J. and Logan, Travis and Tolson, Bryan A. and Han, Ming and Gravel, Francis and Langlois, S{\'e}bastien},
+  year = {2023},
+  journal = {Environmental Modelling \& Software},
+  volume = {168},
+  pages = {105808},
+  doi = {10.1016/j.envsoft.2023.105808},
+}

--- a/docs/source/publications.rst
+++ b/docs/source/publications.rst
@@ -16,6 +16,12 @@ list!
 
 :cite:empty:`Brady2020,Krumhardt2020,Spring2020,Brady2021,Spring2021a,Spring2021b,Zhao2024,Higgins2024,Lesinger2025,Schroers2026,Mangolte2025,Arsenault2023`
 
+2026
+####
+
+.. bibliography::
+  :filter: cited and year and (year == "2026") and docname in docnames
+
 2025
 ####
 

--- a/docs/source/publications.rst
+++ b/docs/source/publications.rst
@@ -6,10 +6,7 @@ Below is a list of publications that have made use of ``climpred`` in their anal
 We appreciate a reference to ``climpred``, e.g., in your acknowledgements section to
 help build the community. Please cite :cite:p:`Brady2021`.
 
-You can also check which papers cite ``climpred`` on Google Scholar:
-
-- https://scholar.google.com/scholar?oi=bibs&hl=en&cites=7715684476250557195&as_sdt=5
-- https://scholar.google.com/scholar?oi=bibs&hl=en&cites=6049472562346270775&as_sdt=5
+You can also check which papers cite ``climpred`` on `Google <https://scholar.google.com/scholar?oi=bibs&hl=en&cites=7715684476250557195&as_sdt=5>`_ `Scholar <https://scholar.google.com/scholar?oi=bibs&hl=en&cites=6049472562346270775&as_sdt=5>`_.
 
 Feel free to open a `Pull Request <contributing.html>`_ to add your publication to the
 list!

--- a/docs/source/publications.rst
+++ b/docs/source/publications.rst
@@ -6,10 +6,39 @@ Below is a list of publications that have made use of ``climpred`` in their anal
 We appreciate a reference to ``climpred``, e.g., in your acknowledgements section to
 help build the community. Please cite :cite:p:`Brady2021`.
 
+You can also check which papers cite ``climpred`` on Google Scholar:
+
+- https://scholar.google.com/scholar?oi=bibs&hl=en&cites=7715684476250557195&as_sdt=5
+- https://scholar.google.com/scholar?oi=bibs&hl=en&cites=6049472562346270775&as_sdt=5
+
 Feel free to open a `Pull Request <contributing.html>`_ to add your publication to the
 list!
 
-:cite:empty:`Brady2020,Krumhardt2020,Spring2020,Brady2021,Spring2021a,Spring2021b`
+:cite:empty:`Brady2020,Krumhardt2020,Spring2020,Brady2021,Spring2021a,Spring2021b,Zhao2024,Higgins2024,Lesinger2025,Schroers2026,Mangolte2025,Arsenault2023`
+
+2025
+####
+
+.. bibliography::
+  :filter: cited and year and (year == "2025") and docname in docnames
+
+2024
+####
+
+.. bibliography::
+  :filter: cited and year and (year == "2024") and docname in docnames
+
+2023
+####
+
+.. bibliography::
+  :filter: cited and year and (year == "2023") and docname in docnames
+
+2022
+####
+
+.. bibliography::
+  :filter: cited and year and (year == "2022") and docname in docnames
 
 2021
 ####


### PR DESCRIPTION
## Summary

- Added Google Scholar citation links to the publications page for checking papers that cite climpred
- Added new citations from 2022-2026 that use climpred for forecast verification/prediction skill analysis:
  - Zhao et al. (2024): Explainable El Niño predictability
  - Higgins & Subramanian (2024): Subseasonal potential predictability in North Pacific
  - Lesinger & Tian (2025): Skillful subseasonal soil moisture drought forecasts
  - Schroers & Martin (2026): Verification of S2S models during extreme precipitation
  - Mangolte et al. (2025): Marine Heatwaves predictability in New Caledonia
  - Arsenault et al. (2023): PAVICS-Hydro platform
- Added year sections (2022-2025) to the publications page