### PR TITLE
Add climpred forecast verification skill for AI coding agents

### DIFF
--- a/.agents/skills/climpred-forecast-verification/SKILL.md
+++ b/.agents/skills/climpred-forecast-verification/SKILL.md
@@ -1,0 +1,253 @@
+---
+name: climpred-forecast-verification
+description: "Verify weather and climate forecasts using climpred. Use when computing forecast skill metrics (RMSE, ACC, CRPS, etc.), comparing hindcasts to observations, bootstrapping significance, removing bias, or working with HindcastEnsemble/PerfectModelEnsemble objects. Triggers on: forecast verification, prediction skill, hindcast, climate prediction, skill score, predictability."
+license: MIT
+---
+
+# climpred — Forecast Verification
+
+climpred verifies weather and climate forecasts. Built on xarray, dask, and xskillscore.
+
+**Docs**: https://climpred.readthedocs.io | **API for LLMs**: https://context7.com/pangeo-data/climpred/llms.txt
+
+## Install
+
+```bash
+pip install climpred[complete]
+# or
+conda install -c conda-forge climpred
+```
+
+## Core Concepts
+
+- **`init`**: initialization time dimension (forecast reference time)
+- **`lead`**: forecast lead time dimension (with units attribute: `"years"`, `"months"`, `"days"`, etc.)
+- **`member`**: ensemble member dimension
+- **`time`**: observation/verification time dimension
+
+## Two Ensemble Classes
+
+### HindcastEnsemble (real-world verification)
+
+```python
+import climpred
+from climpred import HindcastEnsemble
+from climpred.tutorial import load_dataset
+
+# initialized must have dims (init, lead, [member])
+init = load_dataset("CESM-DP-SST")  # dims: (init, lead, member)
+obs = load_dataset("ERSST")  # dims: (time,)
+uninit = load_dataset("CESM-LE")  # dims: (time, member)
+
+hindcast = HindcastEnsemble(init).add_observations(obs).add_uninitialized(uninit)
+
+# Verify
+skill = hindcast.verify(
+    metric="rmse",
+    comparison="e2o",
+    dim="init",
+    alignment="same_inits",
+    reference=["persistence", "climatology", "uninitialized"],
+)
+```
+
+### PerfectModelEnsemble (model-internal verification)
+
+```python
+from climpred import PerfectModelEnsemble
+
+init = load_dataset("MPI-PM-DP-1D")  # dims: (init, lead, member)
+control = load_dataset("MPI-control-1D")  # dims: (time,)
+
+pm = PerfectModelEnsemble(init).add_control(control)
+skill = pm.verify(metric="acc", comparison="m2e", dim=["init", "member"])
+```
+
+## Key Methods
+
+| Method | Description |
+|--------|-------------|
+| `.verify()` | Compute verification skill |
+| `.bootstrap()` | Bootstrap significance testing |
+| `.remove_bias()` | Bias-correct forecasts (HindcastEnsemble only) |
+| `.smooth()` | Temporal/spatial smoothing |
+| `.add_observations()` | Add verification data (HindcastEnsemble) |
+| `.add_uninitialized()` | Add uninitialized ensemble |
+| `.add_control()` | Add control run (PerfectModelEnsemble) |
+| `.plot_alignment()` | Visualize init-verification alignment |
+
+## verify() Parameters
+
+All keyword-only:
+
+- **`metric`** (required): See reference/metrics.md
+- **`comparison`** (required): See reference/comparisons.md
+- **`dim`**: Dimensions to reduce. `None` = all except `lead`. Use `[]` for per-init skill.
+- **`alignment`** (HindcastEnsemble only): `"maximize"`, `"same_inits"`, or `"same_verifs"`
+- **`reference`**: `["persistence", "climatology", "uninitialized"]` or subset
+- **`groupby`**: Group init before verification (e.g., `"month"`, `"season"`)
+- **`**metric_kwargs`**: Passed to metric (e.g., `category_edges` for `rps`)
+
+## bootstrap() Parameters
+
+Same as `verify()` plus:
+
+- **`iterations`**: Number of bootstrap iterations (recommend ≥500)
+- **`sig`**: Significance level in percent (default: 95)
+- **`resample_dim`**: `"member"` (default) or `"init"`
+
+Returns Dataset with `results` dim: `["verify skill", "p", "low_ci", "high_ci"]`
+
+## Comparisons
+
+**HindcastEnsemble**: `"e2o"` (ensemble mean vs obs), `"m2o"` (members vs obs)
+
+**PerfectModelEnsemble**: `"m2m"`, `"m2e"`, `"m2c"`, `"e2c"`
+
+Use `"e2o"` for deterministic metrics, `"m2o"` for probabilistic metrics (CRPS, RPS).
+
+## Common Metrics Quick Reference
+
+| Category | Metrics |
+|----------|---------|
+| Correlation | `pearson_r` (alias: `acc`), `spearman_r` |
+| Distance | `mse`, `rmse`, `mae`, `me` (bias), `median_absolute_error` |
+| Normalized | `nmse`, `nrmse`, `nmae`, `msess` (MSSS) |
+| Percentage | `mape`, `smape` |
+| Probabilistic | `crps`, `crpss`, `crpss_es`, `brier_score`, `rps`, `rank_histogram`, `reliability`, `discrimination`, `roc` |
+| Bias decomposition | `unconditional_bias`, `conditional_bias`, `mul_bias`, `bias_slope`, `msess_murphy` |
+| Other | `uacc`, `std_ratio`, `less` |
+
+**Full metric details**: See reference/metrics.md
+
+## Alignment (HindcastEnsemble only)
+
+- `"maximize"`: Most degrees of freedom; different inits per lead
+- `"same_inits"`: Same initializations across all leads
+- `"same_verifs"`: Same verification dates across all leads
+
+## Bias Removal
+
+```python
+hindcast_corrected = hindcast.remove_bias(
+    alignment="maximize",
+    how="additive_mean",  # or "modified_quantile", "DetrendedQuantileMapping", etc.
+    train_test_split="unfair",  # or "fair" (leave-one-out cross-validation)
+    cv="LOO",  # cross-validation strategy
+)
+```
+
+## Common Workflows
+
+### 1. Deterministic skill with references
+
+```python
+skill = hindcast.verify(
+    metric="acc",
+    comparison="e2o",
+    dim="init",
+    alignment="same_inits",
+    reference=["persistence", "climatology"],
+)
+skill["SST"].plot(hue="skill")
+```
+
+### 2. Probabilistic skill (CRPS)
+
+```python
+skill = hindcast.verify(
+    metric="crps",
+    comparison="m2o",
+    dim=["init", "member"],
+    alignment="same_verifs",
+)
+```
+
+### 3. Bootstrap significance
+
+```python
+bs = hindcast.bootstrap(
+    metric="acc",
+    comparison="e2o",
+    dim="init",
+    alignment="same_inits",
+    iterations=500,
+    reference=["persistence", "climatology"],
+)
+# p < 0.05 means initialized beats reference
+```
+
+### 4. Per-init skill (no dimension reduction)
+
+```python
+skill = hindcast.verify(
+    metric="rmse",
+    comparison="e2o",
+    dim=[],
+    alignment="same_verifs",
+)
+```
+
+### 5. Seasonal groupby
+
+```python
+skill = hindcast.verify(
+    metric="acc",
+    comparison="e2o",
+    dim="init",
+    alignment="same_inits",
+    groupby="month",
+)
+```
+
+## Data Requirements
+
+**Initialized forecast** (`init`):
+- Must have `init` (initialization time) and `lead` dimensions
+- `lead` must have a `units` attribute: `"years"`, `"months"`, `"days"`, etc.
+- Optional: `member` dimension for ensemble
+
+**Observations** (`obs`):
+- Must have `time` dimension
+- Variables must match initialized dataset
+
+**Lead units attribute** — set before creating ensemble:
+```python
+ds["lead"].attrs["units"] = "years"
+```
+
+## Tutorial Datasets
+
+```python
+from climpred.tutorial import load_dataset
+
+# call load_dataset() without args to list all available datasets
+
+# Decadal (HindcastEnsemble)
+init = load_dataset("CESM-DP-SST")
+obs = load_dataset("ERSST")
+uninit = load_dataset("CESM-LE")
+
+# Perfect model
+init_pm = load_dataset("MPI-PM-DP-1D")
+control = load_dataset("MPI-control-1D")
+
+# Subseasonal
+s2s_init = load_dataset("ECMWF_S2S_Germany")
+s2s_obs = load_dataset("Observations_Germany")
+```
+
+## Gotchas
+
+1. **`dim` must match comparison**: Use `dim="init"` with `comparison="e2o"` (no member dim). Use `dim=["init", "member"]` with `comparison="m2o"`.
+2. **Lead units**: Always set `ds["lead"].attrs["units"]` before creating the ensemble.
+3. **Integer init coords**: Auto-converted to annual cftime. Use cftime or datetime init coords for sub-annual data.
+4. **`alignment` is required** for `HindcastEnsemble.verify()` (not for PerfectModelEnsemble).
+5. **`reference="uninitialized"`** requires `.add_uninitialized()` first.
+
+## Advanced: reference files
+
+- **Setting up data & toy examples**: See reference/setting_up_data.md
+- **Bias removal guide**: See reference/bias_removal.md
+- **Full metrics catalog**: See reference/metrics.md
+- **Comparisons detail**: See reference/comparisons.md

--- a/.agents/skills/climpred-forecast-verification/reference/bias_removal.md
+++ b/.agents/skills/climpred-forecast-verification/reference/bias_removal.md
@@ -1,0 +1,295 @@
+# Bias Removal in climpred
+
+## Contents
+- [Overview](#overview)
+- [Method: remove_bias()](#method-remove_bias)
+- [Bias Correction Methods (how)](#bias-correction-methods-how)
+- [Train/Test Split Strategies](#traintest-split-strategies)
+- [Seasonality Options](#seasonality-options)
+- [Workflow Examples](#workflow-examples)
+- [Common Pitfalls](#common-pitfalls)
+
+## Overview
+
+Climate models have systematic biases relative to observations. `HindcastEnsemble.remove_bias()` corrects these before verification. Bias is calculated per lead time and grouped by seasonality (default: `"month"`).
+
+The method returns a new `HindcastEnsemble` with corrected forecasts — it does not modify in place.
+
+```python
+corrected = hindcast.remove_bias(alignment="same_verifs", how="additive_mean")
+skill = corrected.verify(
+    metric="rmse", comparison="e2o", dim="init", alignment="same_verifs"
+)
+```
+
+## Method: remove_bias()
+
+```python
+HindcastEnsemble.remove_bias(
+    alignment,  # required: "maximize", "same_inits", "same_verifs"
+    how="additive_mean",  # bias correction method
+    train_test_split="unfair",  # "unfair", "unfair-cv", "fair"
+    train_init=None,  # slice or DataArray for fair split (with same_inits/maximize)
+    train_time=None,  # slice or DataArray for fair split (with same_verifs)
+    cv=False,  # "LOO" for leave-one-out (with unfair-cv)
+    **metric_kwargs,  # passed to xclim.sdba or bias_correction
+)
+```
+
+**Returns**: `HindcastEnsemble` with bias-corrected initialized forecasts.
+
+## Bias Correction Methods (how)
+
+### Built-in methods (no extra dependencies)
+
+| Method | Description |
+|--------|-------------|
+| `"additive_mean"` | Subtract mean bias (forecast - obs). Default. |
+| `"multiplicative_mean"` | Divide by multiplicative bias ratio. |
+| `"multiplicative_std"` | Correct ensemble spread to match observed variability. |
+
+### bias_correction package methods (requires `pip install bias-correction`)
+
+| Method | Description |
+|--------|-------------|
+| `"modified_quantile"` | Modified quantile mapping |
+| `"basic_quantile"` | Basic quantile mapping |
+| `"gamma_mapping"` | Gamma distribution mapping |
+| `"normal_mapping"` | Normal distribution mapping |
+
+### xclim.sdba methods (requires `pip install xclim`)
+
+| Method | Description |
+|--------|-------------|
+| `"EmpiricalQuantileMapping"` | Empirical quantile mapping |
+| `"DetrendedQuantileMapping"` | Detrended quantile mapping |
+| `"PrincipalComponents"` | Principal components adjustment |
+| `"QuantileDeltaMapping"` | Quantile delta mapping |
+| `"Scaling"` | Additive or multiplicative scaling |
+| `"LOCI"` | Local intensity scaling |
+
+**Note**: xclim methods require `pint`-compatible `units` attribute on the data variable:
+```python
+hindcast._datasets["initialized"]["sst"].attrs["units"] = "C"
+hindcast._datasets["observations"]["sst"].attrs["units"] = "C"
+```
+
+When using xclim methods, pass `group` instead of relying on `set_options(seasonality=...)`:
+```python
+hindcast.remove_bias(
+    alignment="same_inits", how="EmpiricalQuantileMapping", group="init"
+)
+```
+
+## Train/Test Split Strategies
+
+Based on Risbey et al. (2021, doi:10/gk8k7k):
+
+### unfair (default)
+
+Train and test periods completely overlap. Fast, easy, but optimistically biased — the model "sees" verification data during bias estimation.
+
+```python
+hindcast.remove_bias(
+    alignment="same_verifs", how="additive_mean", train_test_split="unfair"
+)
+```
+
+### unfair-cv
+
+Train and test overlap except the current initialization is left out (leave-one-out cross-validation). Slightly more honest than unfair. Slower.
+
+```python
+hindcast.remove_bias(
+    alignment="same_verifs",
+    how="additive_mean",
+    train_test_split="unfair-cv",
+    cv="LOO",
+)
+```
+
+### fair (recommended for publication)
+
+No overlap between train and test. You must specify which period to use for training. Remaining initializations are the test set.
+
+With `alignment="same_inits"` or `"maximize"`, provide `train_init`:
+```python
+hindcast.remove_bias(
+    alignment="same_inits",
+    how="additive_mean",
+    train_test_split="fair",
+    train_init=slice("1960", "1990"),  # train on 1960-1990, test on rest
+)
+```
+
+With `alignment="same_verifs"`, provide `train_time`:
+```python
+hindcast.remove_bias(
+    alignment="same_verifs",
+    how="additive_mean",
+    train_test_split="fair",
+    train_time=slice("1982", "1998"),  # train on obs time 1982-1998
+)
+```
+
+### Comparison
+
+| Strategy | Speed | Fair? | Use case |
+|----------|-------|-------|----------|
+| `"unfair"` | Fast | No | Quick exploration |
+| `"unfair-cv"` | Slow | Partially | Better than unfair, worse than fair |
+| `"fair"` | Fast | Yes | Publication, operational comparison |
+
+## Seasonality Options
+
+Bias is grouped by seasonality before removal. Control via `climpred.set_options`:
+
+```python
+import climpred
+
+# Default: monthly seasonality
+climpred.set_options(seasonality="month")
+
+# For daily data — finer grouping
+climpred.set_options(seasonality="dayofyear")
+
+# For seasonal data
+climpred.set_options(seasonality="season")
+
+# Available: "dayofyear", "weekofyear", "month", "season"
+```
+
+The seasonality option also affects `reference="climatology"` in `verify()`.
+
+## Workflow Examples
+
+### 1. Basic additive mean bias removal
+
+```python
+from climpred import HindcastEnsemble
+from climpred.tutorial import load_dataset
+
+init = load_dataset("CESM-DP-SST")
+obs = load_dataset("ERSST")
+hindcast = HindcastEnsemble(init).add_observations(obs)
+
+# Remove bias and verify
+corrected = hindcast.remove_bias(alignment="maximize", how="additive_mean")
+skill = corrected.verify(
+    metric="rmse",
+    comparison="e2o",
+    dim="init",
+    alignment="maximize",
+)
+```
+
+### 2. Compare raw vs bias-corrected skill
+
+```python
+metric_kwargs = dict(
+    metric="rmse", comparison="e2o", dim="init", alignment="same_verifs"
+)
+
+raw_skill = hindcast.verify(**metric_kwargs)
+corrected_skill = hindcast.remove_bias(
+    alignment="same_verifs",
+    how="additive_mean",
+    train_test_split="unfair",
+).verify(**metric_kwargs)
+
+raw_skill["SST"].plot(label="raw")
+corrected_skill["SST"].plot(label="bias corrected")
+```
+
+### 3. Fair train/test split for publication
+
+```python
+corrected = hindcast.remove_bias(
+    alignment="same_inits",
+    how="additive_mean",
+    train_test_split="fair",
+    train_init=slice("1954", "1980"),  # first half for training
+)
+
+# Only test-period initializations remain
+skill = corrected.verify(
+    metric="acc",
+    comparison="e2o",
+    dim="init",
+    alignment="same_inits",
+    reference=["persistence", "climatology"],
+)
+```
+
+### 4. Quantile mapping with xclim
+
+```python
+# Requires: pip install xclim
+# Variables need units attribute for xclim
+hindcast._datasets["initialized"]["SST"].attrs["units"] = "K"
+hindcast._datasets["observations"]["SST"].attrs["units"] = "K"
+
+corrected = hindcast.remove_bias(
+    alignment="same_inits",
+    how="EmpiricalQuantileMapping",
+    train_test_split="unfair",
+    group="init",  # passed to xclim.sdba
+)
+```
+
+### 5. Multiplicative std correction (ensemble calibration)
+
+```python
+corrected = hindcast.remove_bias(
+    alignment="maximize",
+    how="multiplicative_std",
+    train_test_split="unfair",
+)
+# Ensemble spread now matches observed variability
+```
+
+### 6. Seasonal bias removal with NMME data
+
+```python
+init = load_dataset("NMME_hindcast_Nino34_sst")
+obs = load_dataset("NMME_OIv2_Nino34_sst")
+
+hindcast = HindcastEnsemble(init.sel(model="GFDL-CM2p5-FLOR-A06")).add_observations(obs)
+
+# Monthly seasonality (default) is appropriate for seasonal forecasts
+corrected = hindcast.remove_bias(
+    alignment="same_verifs",
+    how="additive_mean",
+    train_test_split="fair",
+    train_time=slice("1982", "1998"),
+)
+```
+
+### 7. Diagnose the bias before removing it
+
+```python
+# Visualize bias as function of lead and init
+bias = hindcast.verify(
+    metric="additive_bias",
+    comparison="e2o",
+    dim=[],
+    alignment="same_verifs",
+)
+bias["SST"].plot()  # QuadMesh: x=init, y=lead
+```
+
+## Common Pitfalls
+
+1. **`train_init` / `train_time` required for fair split**: With `train_test_split="fair"`, you must provide `train_init` (for `alignment="same_inits"` or `"maximize"`) or `train_time` (for `alignment="same_verifs"`). Otherwise climpred raises `ValueError`.
+
+2. **xclim requires units**: xclim.sdba methods need a `units` attribute on data variables. Set it manually if missing: `ds["var"].attrs["units"] = "K"`.
+
+3. **Fair split reduces sample size**: The fair split drops training initializations from the test set. Skill may appear worse with fewer initializations — this is the honest cost of avoiding data leakage.
+
+4. **cv="LOO" is discouraged**: Leave-one-out cross-validation is slow and has known issues. Use `train_test_split="fair"` instead for a clean separation.
+
+5. **Seasonality must match data frequency**: Don't use `seasonality="dayofyear"` with monthly data — it will produce incorrect groupings. Match the seasonality to your data resolution.
+
+6. **Bias removal is per-lead**: Bias is computed and removed independently at each lead time, which is the correct approach since model drift typically varies with lead.
+
+7. **Chain with verify()**: `remove_bias()` returns a new `HindcastEnsemble`, so chain it: `hindcast.remove_bias(...).verify(...)`.

--- a/.agents/skills/climpred-forecast-verification/reference/comparisons.md
+++ b/.agents/skills/climpred-forecast-verification/reference/comparisons.md
@@ -1,0 +1,77 @@
+# climpred Comparisons Reference
+
+## Contents
+- [HindcastEnsemble Comparisons](#hindcastensemble-comparisons)
+- [PerfectModelEnsemble Comparisons](#perfectmodelensemble-comparisons)
+- [Choosing a Comparison](#choosing-a-comparison)
+
+## HindcastEnsemble Comparisons
+
+| Comparison | Aliases | Type | Description |
+|-----------|---------|------|-------------|
+| `e2o` | `e2r` | Deterministic only | Ensemble mean vs observations |
+| `m2o` | `m2r` | Deterministic + Probabilistic | Each member vs observations |
+
+### e2o (ensemble mean vs observations)
+- Computes ensemble mean first, then compares to observations
+- Use for deterministic metrics (`acc`, `rmse`, `mae`, `msess`, etc.)
+- `dim` should NOT include `"member"`
+
+```python
+hindcast.verify(metric="rmse", comparison="e2o", dim="init", alignment="same_inits")
+```
+
+### m2o (members vs observations)
+- Compares each member individually to observations
+- Required for probabilistic metrics (`crps`, `rps`, `brier_score`, etc.)
+- `dim` must include `"member"` for probabilistic metrics
+
+```python
+hindcast.verify(
+    metric="crps", comparison="m2o", dim=["init", "member"], alignment="same_inits"
+)
+```
+
+## PerfectModelEnsemble Comparisons
+
+| Comparison | Type | Description |
+|-----------|------|-------------|
+| `m2m` | Deterministic + Probabilistic | All members vs all other members (leave-one-out) |
+| `m2e` | Deterministic + Probabilistic | Each member vs ensemble mean |
+| `m2c` | Deterministic + Probabilistic | Each member vs control run |
+| `e2c` | Deterministic only | Ensemble mean vs control run |
+
+### m2m (member-to-member)
+Each member is verified against every other member in turn. The verifying member is excluded from the forecast.
+
+### m2e (member-to-ensemble-mean)
+Each member is verified against the ensemble mean (with that member excluded from the mean).
+
+### m2c (member-to-control)
+Each member is verified against the control simulation. Only available when `.add_control()` has been called.
+
+### e2c (ensemble-mean-to-control)
+The ensemble mean is verified against the control simulation. Deterministic only.
+
+## Choosing a Comparison
+
+### For HindcastEnsemble:
+- **Deterministic metrics** → `"e2o"` (ensemble mean provides best deterministic estimate)
+- **Probabilistic metrics** → `"m2o"` (need individual members for ensemble distribution)
+
+### For PerfectModelEnsemble:
+- **Standard analysis** → `"m2e"` (common default, accounts for ensemble structure)
+- **Cross-validated** → `"m2m"` (more degrees of freedom, more expensive)
+- **Against external reference** → `"m2c"` or `"e2c"` (requires control run)
+
+### dim and comparison must be consistent:
+```python
+# CORRECT: e2o with dim="init" (no member)
+hindcast.verify(metric="rmse", comparison="e2o", dim="init", ...)
+
+# CORRECT: m2o with dim=["init", "member"]
+hindcast.verify(metric="crps", comparison="m2o", dim=["init", "member"], ...)
+
+# WRONG: e2o with dim including "member" — will error
+# hindcast.verify(metric="rmse", comparison="e2o", dim=["init", "member"], ...)
+```

--- a/.agents/skills/climpred-forecast-verification/reference/metrics.md
+++ b/.agents/skills/climpred-forecast-verification/reference/metrics.md
@@ -1,0 +1,134 @@
+# climpred Metrics Reference
+
+## Contents
+- [Deterministic Correlation Metrics](#deterministic-correlation-metrics)
+- [Deterministic Distance Metrics](#deterministic-distance-metrics)
+- [Normalized Distance Metrics](#normalized-distance-metrics)
+- [Bias Decomposition Metrics](#bias-decomposition-metrics)
+- [Probabilistic Metrics](#probabilistic-metrics)
+- [Contingency Metrics](#contingency-metrics)
+- [Metric Selection Guide](#metric-selection-guide)
+
+## Deterministic Correlation Metrics
+
+| Metric | Aliases | Range | Perfect | Description |
+|--------|---------|-------|---------|-------------|
+| `pearson_r` | `acc`, `corr` | [-1, 1] | 1 | Anomaly correlation coefficient |
+| `pearson_r_p_value` | `p`, `p_val` | [0, 1] | 0 | p-value for Pearson r |
+| `pearson_r_eff_p_value` | `p_eff` | [0, 1] | 0 | p-value with effective sample size |
+| `effective_sample_size` | `n_eff` | [0, ∞] | — | Effective sample size (autocorrelation-adjusted) |
+| `spearman_r` | `sacc` | [-1, 1] | 1 | Spearman rank correlation |
+| `spearman_r_p_value` | `sp` | [0, 1] | 0 | p-value for Spearman r |
+| `spearman_r_eff_p_value` | `sp_eff` | [0, 1] | 0 | p-value with effective sample size |
+
+## Deterministic Distance Metrics
+
+| Metric | Aliases | Range | Perfect | Description |
+|--------|---------|-------|---------|-------------|
+| `mse` | — | [0, ∞] | 0 | Mean squared error |
+| `rmse` | — | [0, ∞] | 0 | Root mean squared error |
+| `mae` | — | [0, ∞] | 0 | Mean absolute error |
+| `me` | `bias` | (-∞, ∞) | 0 | Mean error (bias) |
+| `median_absolute_error` | — | [0, ∞] | 0 | Median absolute error |
+| `mape` | — | [0, ∞] | 0 | Mean absolute percentage error |
+| `smape` | — | [0, 200] | 0 | Symmetric mean absolute percentage error |
+
+## Normalized Distance Metrics
+
+These are normalized by verification variance. Perfect score = 0 (or 1 for MSESS).
+
+| Metric | Aliases | Range | Perfect | Description |
+|--------|---------|-------|---------|-------------|
+| `nmse` | `nev` | [0, ∞] | 0 | Normalized MSE (1 = no skill) |
+| `nmae` | — | [0, ∞] | 0 | Normalized MAE |
+| `nrmse` | — | [0, ∞] | 0 | Normalized RMSE (1 = no skill) |
+| `msess` | `ppp`, `msss` | (-∞, 1] | 1 | MSE skill score (1 - NMSE) |
+
+## Bias Decomposition Metrics
+
+Murphy (1988) decomposition of MSE into reliability, resolution, and uncertainty.
+
+| Metric | Aliases | Range | Perfect | Description |
+|--------|---------|-------|---------|-------------|
+| `unconditional_bias` | `u_b`, `additive_bias` | (-∞, ∞) | 0 | Unconditional (additive) bias |
+| `mul_bias` | `m_b`, `multiplicative_bias` | [0, ∞] | 1 | Multiplicative bias (std ratio × r) |
+| `conditional_bias` | `c_b`, `cond_bias` | [0, ∞] | 1 | Conditional bias |
+| `bias_slope` | — | (-∞, ∞) | 1 | Slope of forecast vs observed regression |
+| `uacc` | — | (-∞, 1] | 1 | Unbiased ACC |
+| `std_ratio` | — | [0, ∞] | 1 | Standard deviation ratio (fcst/obs) |
+| `msess_murphy` | `msss_murphy` | (-∞, 1] | 1 | MSESS via Murphy decomposition |
+| `spread` | — | [0, ∞] | — | Ensemble spread (std over member) |
+
+## Probabilistic Metrics
+
+**Require `comparison="m2o"` (HindcastEnsemble) or `"m2m"/"m2c"` (PerfectModelEnsemble).**
+**`dim` must include `"member"`.**
+
+| Metric | Aliases | Range | Perfect | Description |
+|--------|---------|-------|---------|-------------|
+| `crps` | — | [0, ∞] | 0 | Continuous Ranked Probability Score |
+| `crpss` | — | (-∞, 1] | 1 | CRPS skill score (vs climatology) |
+| `crpss_es` | — | (-∞, 1] | 1 | CRPS skill score (vs Gaussian spread) |
+| `brier_score` | `bs` | [0, 1] | 0 | Brier Score (requires `category_edges`) |
+| `threshold_brier_score` | `tbs` | [0, 1] | 0 | Brier Score at thresholds |
+| `rps` | — | [0, 1] | 0 | Ranked Probability Score (requires `category_edges`) |
+| `discrimination` | — | — | — | Discrimination histogram |
+| `reliability` | — | — | — | Reliability diagram values |
+| `rank_histogram` | — | — | uniform | Rank histogram (Talagrand diagram) |
+| `roc` | — | [0, 1] | 1 | Receiver Operating Characteristic area |
+| `less` | — | — | — | Logarithmic Ensemble Spread Score |
+
+### Probabilistic metric kwargs
+
+**`brier_score`** and **`rps`** require `category_edges`:
+```python
+hindcast.verify(
+    metric="rps",
+    comparison="m2o",
+    dim=["init", "member"],
+    alignment="same_inits",
+    category_edges=np.array([0, 0.5, 1.0]),  # bin edges
+)
+```
+
+**`threshold_brier_score`** requires `threshold`:
+```python
+hindcast.verify(
+    metric="threshold_brier_score",
+    comparison="m2o",
+    dim=["init", "member"],
+    alignment="same_inits",
+    threshold=0.5,
+)
+```
+
+## Contingency Metrics
+
+Use `metric="contingency"` with `score` kwarg:
+
+```python
+hindcast.verify(
+    metric="contingency",
+    comparison="m2o",
+    dim=["init", "member"],
+    alignment="same_inits",
+    score="accuracy",  # or any xskillscore.Contingency method
+    observation_category_edges=np.array([-np.inf, 0, np.inf]),
+    forecast_category_edges=np.array([-np.inf, 0, np.inf]),
+)
+```
+
+Available `score` values: `"accuracy"`, `"bias_score"`, `"hit_rate"`, `"false_alarm_rate"`, `"false_alarm_ratio"`, `"odds_ratio"`, `"odds_ratio_skill_score"`, `"heidke_score"`, `"peirce_score"`, `"gerrity_score"`
+
+## Metric Selection Guide
+
+| Goal | Recommended Metric | Comparison |
+|------|-------------------|------------|
+| Correlation skill | `acc` (pearson_r) | `e2o` |
+| Error magnitude | `rmse` or `mae` | `e2o` |
+| Bias | `me` | `e2o` |
+| Normalized skill (comparable across vars) | `msess` or `nrmse` | `e2o` |
+| Ensemble reliability | `crps` | `m2o` |
+| Categorical skill | `brier_score` or `rps` | `m2o` |
+| Ensemble spread-skill | `spread` vs `rmse` | `m2o` / `e2o` |
+| Statistical significance | `pearson_r_eff_p_value` | `e2o` |

--- a/.agents/skills/climpred-forecast-verification/reference/setting_up_data.md
+++ b/.agents/skills/climpred-forecast-verification/reference/setting_up_data.md
@@ -1,0 +1,351 @@
+# Setting Up Data for climpred
+
+## Contents
+- [Dimension Requirements](#dimension-requirements)
+- [Creating Toy HindcastEnsemble from Scratch](#creating-toy-hindcastensemble-from-scratch)
+- [Creating Toy PerfectModelEnsemble from Scratch](#creating-toy-perfectmodelensemble-from-scratch)
+- [CF Convention Auto-Renaming](#cf-convention-auto-renaming)
+- [Converting Raw Model Output](#converting-raw-model-output)
+- [Common Pitfalls](#common-pitfalls)
+
+## Dimension Requirements
+
+### Initialized forecast dataset
+
+| Dimension | Type | Required | Notes |
+|-----------|------|----------|-------|
+| `init` | `pd.DatetimeIndex` or `xr.CFTimeIndex` | Yes | Initialization dates. `int` auto-converted to annual cftime. |
+| `lead` | `int` or `float` | Yes | Lead time steps. **Must** have `units` attribute. |
+| `member` | `int` or `str` | Only for probabilistic | Ensemble members |
+| spatial dims | any | No | `lat`, `lon`, `depth`, etc. are broadcast |
+
+**`lead` units attribute** — valid values:
+`"years"`, `"seasons"`, `"months"`, `"weeks"`, `"pentads"`, `"days"`, `"hours"`, `"minutes"`, `"seconds"`
+
+### Observations / verification dataset
+
+| Dimension | Type | Required | Notes |
+|-----------|------|----------|-------|
+| `time` | `pd.DatetimeIndex` or `xr.CFTimeIndex` | Yes | Must cover the verification period |
+| spatial dims | any | No | Must match initialized dims |
+
+Variables must overlap with initialized dataset.
+
+### Uninitialized ensemble (optional)
+
+| Dimension | Type | Required | Notes |
+|-----------|------|----------|-------|
+| `time` | `pd.DatetimeIndex` or `xr.CFTimeIndex` | Yes | |
+| `member` | `int` or `str` | No | |
+
+## Creating Toy HindcastEnsemble from Scratch
+
+### Minimal example (annual, deterministic)
+
+```python
+import numpy as np
+import pandas as pd
+import xarray as xr
+from climpred import HindcastEnsemble
+
+# Dimensions
+inits = pd.date_range("2000", periods=10, freq="YS")  # 10 initializations
+leads = np.arange(1, 4)  # 3 lead years
+
+# Create initialized forecast
+init_data = np.random.randn(len(inits), len(leads))
+initialized = xr.Dataset(
+    {"temperature": (["init", "lead"], init_data)},
+    coords={"init": inits, "lead": leads},
+)
+initialized["lead"].attrs["units"] = "years"
+
+# Create observations
+obs_time = pd.date_range("2000", periods=15, freq="YS")
+obs = xr.Dataset(
+    {"temperature": ("time", np.random.randn(len(obs_time)))},
+    coords={"time": obs_time},
+)
+
+# Build ensemble and verify
+hindcast = HindcastEnsemble(initialized).add_observations(obs)
+skill = hindcast.verify(
+    metric="rmse",
+    comparison="e2o",
+    dim="init",
+    alignment="same_inits",
+)
+```
+
+### With ensemble members (probabilistic)
+
+```python
+import numpy as np
+import pandas as pd
+import xarray as xr
+from climpred import HindcastEnsemble
+
+inits = pd.date_range("2000", periods=10, freq="YS")
+leads = np.arange(1, 6)  # 5 lead years
+members = np.arange(1, 11)  # 10 members
+
+# Initialized forecast with member dimension
+init_data = np.random.randn(len(inits), len(leads), len(members))
+initialized = xr.Dataset(
+    {"sst": (["init", "lead", "member"], init_data)},
+    coords={"init": inits, "lead": leads, "member": members},
+)
+initialized["lead"].attrs["units"] = "years"
+
+# Observations
+obs_time = pd.date_range("2000", periods=15, freq="YS")
+obs = xr.Dataset(
+    {"sst": ("time", np.random.randn(len(obs_time)))},
+    coords={"time": obs_time},
+)
+
+# Uninitialized ensemble (optional, for reference="uninitialized")
+uninit = xr.Dataset(
+    {"sst": (["time", "member"], np.random.randn(len(obs_time), len(members)))},
+    coords={"time": obs_time, "member": members},
+)
+
+hindcast = HindcastEnsemble(initialized).add_observations(obs).add_uninitialized(uninit)
+
+# Deterministic verification
+skill = hindcast.verify(
+    metric="acc",
+    comparison="e2o",
+    dim="init",
+    alignment="same_inits",
+    reference=["persistence", "climatology", "uninitialized"],
+)
+
+# Probabilistic verification
+crps = hindcast.verify(
+    metric="crps",
+    comparison="m2o",
+    dim=["init", "member"],
+    alignment="same_verifs",
+)
+```
+
+### Monthly data
+
+```python
+import numpy as np
+import pandas as pd
+import xarray as xr
+from climpred import HindcastEnsemble
+
+inits = pd.date_range("2000-01", periods=24, freq="MS")  # 24 monthly inits
+leads = np.arange(1, 7)  # 6 lead months
+members = np.arange(1, 6)
+
+init_data = np.random.randn(len(inits), len(leads), len(members))
+initialized = xr.Dataset(
+    {"precip": (["init", "lead", "member"], init_data)},
+    coords={"init": inits, "lead": leads, "member": members},
+)
+initialized["lead"].attrs["units"] = "months"  # monthly leads
+
+obs_time = pd.date_range("2000-01", periods=36, freq="MS")
+obs = xr.Dataset(
+    {"precip": ("time", np.random.randn(len(obs_time)))},
+    coords={"time": obs_time},
+)
+
+hindcast = HindcastEnsemble(initialized).add_observations(obs)
+```
+
+### Daily data (subseasonal / weather)
+
+```python
+import numpy as np
+import pandas as pd
+import xarray as xr
+from climpred import HindcastEnsemble
+
+inits = pd.date_range("2020-01-01", periods=30, freq="7D")  # weekly inits
+leads = np.arange(1, 15)  # 14 lead days
+members = np.arange(1, 5)
+
+init_data = np.random.randn(len(inits), len(leads), len(members))
+initialized = xr.Dataset(
+    {"t2m": (["init", "lead", "member"], init_data)},
+    coords={"init": inits, "lead": leads, "member": members},
+)
+initialized["lead"].attrs["units"] = "days"
+
+obs_time = pd.date_range("2020-01-01", periods=120, freq="D")
+obs = xr.Dataset(
+    {"t2m": ("time", np.random.randn(len(obs_time)))},
+    coords={"time": obs_time},
+)
+
+hindcast = HindcastEnsemble(initialized).add_observations(obs)
+```
+
+### With spatial dimensions (lat/lon)
+
+```python
+import numpy as np
+import pandas as pd
+import xarray as xr
+from climpred import HindcastEnsemble
+
+inits = pd.date_range("2000", periods=10, freq="YS")
+leads = np.arange(1, 4)
+members = np.arange(1, 4)
+lats = np.arange(-90, 91, 30)
+lons = np.arange(0, 360, 60)
+
+init_data = np.random.randn(len(inits), len(leads), len(members), len(lats), len(lons))
+initialized = xr.Dataset(
+    {"sst": (["init", "lead", "member", "lat", "lon"], init_data)},
+    coords={
+        "init": inits,
+        "lead": leads,
+        "member": members,
+        "lat": lats,
+        "lon": lons,
+    },
+)
+initialized["lead"].attrs["units"] = "years"
+
+obs_time = pd.date_range("2000", periods=15, freq="YS")
+obs_data = np.random.randn(len(obs_time), len(lats), len(lons))
+obs = xr.Dataset(
+    {"sst": (["time", "lat", "lon"], obs_data)},
+    coords={"time": obs_time, "lat": lats, "lon": lons},
+)
+
+hindcast = HindcastEnsemble(initialized).add_observations(obs)
+
+# Verify over init only — keeps lat/lon
+skill = hindcast.verify(
+    metric="acc",
+    comparison="e2o",
+    dim="init",
+    alignment="same_inits",
+)
+
+# Verify over all dims — scalar result per lead
+skill_all = hindcast.verify(
+    metric="rmse",
+    comparison="e2o",
+    dim=None,
+    alignment="same_inits",
+)
+```
+
+## Creating Toy PerfectModelEnsemble from Scratch
+
+```python
+import numpy as np
+import pandas as pd
+import xarray as xr
+from climpred import PerfectModelEnsemble
+
+inits = pd.date_range("2000", periods=5, freq="YS")
+leads = np.arange(1, 11)  # 10 lead years
+members = np.arange(1, 4)
+
+init_data = np.random.randn(len(inits), len(leads), len(members))
+initialized = xr.Dataset(
+    {"tos": (["init", "lead", "member"], init_data)},
+    coords={"init": inits, "lead": leads, "member": members},
+)
+initialized["lead"].attrs["units"] = "years"
+
+# Control run — long unforced simulation
+control_time = pd.date_range("1850", periods=300, freq="YS")
+control = xr.Dataset(
+    {"tos": ("time", np.random.randn(len(control_time)))},
+    coords={"time": control_time},
+)
+
+pm = PerfectModelEnsemble(initialized).add_control(control)
+skill = pm.verify(metric="acc", comparison="m2e", dim=["init", "member"])
+```
+
+## CF Convention Auto-Renaming
+
+climpred auto-renames dimensions if they have CF `standard_name` attributes:
+
+| CF standard_name | Renamed to |
+|-----------------|------------|
+| `forecast_reference_time` | `init` |
+| `forecast_period` | `lead` |
+| `realization` | `member` |
+
+```python
+# This works — climpred renames "S" to "init", "L" to "lead", "M" to "member"
+ds = xr.Dataset(
+    {"temp": (["S", "L", "M"], np.random.randn(5, 3, 2))},
+    coords={
+        "S": pd.date_range("2000", periods=5, freq="YS"),
+        "L": [1, 2, 3],
+        "M": [0, 1],
+    },
+)
+ds["S"].attrs["standard_name"] = "forecast_reference_time"
+ds["L"].attrs["standard_name"] = "forecast_period"
+ds["L"].attrs["units"] = "years"
+ds["M"].attrs["standard_name"] = "realization"
+
+hindcast = HindcastEnsemble(ds)  # auto-renames to init, lead, member
+```
+
+Also, `climpred.preprocessing.shared.rename_SLM_to_climpred_dims()` renames `S`→`init`, `L`→`lead`, `M`→`member` directly (for SubX/CESM conventions).
+
+## Converting Raw Model Output
+
+To convert multiple simulation files (each with a `time` dimension) into climpred format:
+
+```python
+import xarray as xr
+import numpy as np
+
+# Suppose you have files: init2000_member1.nc, init2000_member2.nc, etc.
+init_list = []
+for init_year in range(2000, 2010):
+    member_list = []
+    for member in range(1, 6):
+        ds = xr.open_dataset(f"init{init_year}_member{member}.nc")
+        # Convert time to integer lead steps
+        ds = ds.rename({"time": "lead"})
+        ds["lead"] = np.arange(1, len(ds.lead) + 1)
+        member_list.append(ds)
+    member_ds = xr.concat(member_list, dim="member")
+    member_ds["member"] = range(1, 6)
+    init_list.append(member_ds)
+
+initialized = xr.concat(init_list, dim="init")
+initialized["init"] = pd.date_range("2000", periods=10, freq="YS")
+initialized["lead"].attrs["units"] = "years"
+```
+
+Or use the built-in helper:
+```python
+from climpred.preprocessing.shared import load_hindcast
+
+ds = load_hindcast(inits=range(2000, 2010), members=range(1, 6))
+ds["lead"].attrs["units"] = "years"
+```
+
+## Common Pitfalls
+
+1. **Missing `lead` units**: Always set `ds["lead"].attrs["units"] = "years"` (or appropriate unit) before creating the ensemble. Without it, climpred raises an error.
+
+2. **Integer `init` coordinates**: If `init` is integer (e.g., `[2000, 2001, 2002]`), climpred assumes annual data and converts to `cftime.DatetimeProlepticGregorian`. For sub-annual data, use `pd.DatetimeIndex` or `xr.CFTimeIndex`.
+
+3. **`time` vs `init`**: Observations use `time`. Forecasts use `init` + `lead`. Do not use `time` in initialized datasets.
+
+4. **Variable name mismatch**: Variables in initialized and observations must have the same names. Only shared variables are verified.
+
+5. **Calendar mismatch**: initialized (`init`) and observations (`time`) should use the same calendar type. climpred will warn or error on mismatches.
+
+6. **Lead starting at 0 vs 1**: `lead` can start at 0 or 1 — just be consistent. `lead=0` represents the initialization itself (analysis time).
+
+7. **`valid_time`**: climpred computes `valid_time = init + lead` automatically. Do not set this manually.

--- a/.agents/skills/climpred-forecast-verification/reference/setting_up_data.md
+++ b/.agents/skills/climpred-forecast-verification/reference/setting_up_data.md
@@ -349,3 +349,9 @@ ds["lead"].attrs["units"] = "years"
 6. **Lead starting at 0 vs 1**: `lead` can start at 0 or 1 — just be consistent. `lead=0` represents the initialization itself (analysis time).
 
 7. **`valid_time`**: climpred computes `valid_time = init + lead` automatically. Do not set this manually.
+
+8. **Observation time must cover verification period**: The `time` dimension in observations should span the entire period you want to verify against. climpred aligns `init + lead` to find matching observation times. You only need to provide observations with a `time` coordinate — do NOT include a `lead` dimension in observations.
+
+9. **Unique time indices**: Observation time indices must be unique. Avoid duplicate timestamps in the `time` dimension.
+
+10. **Avoid integer coordinates for annual data**: When creating toy data, prefer `pd.date_range` for both `init` and observation `time` rather than using integer coordinates. This avoids ambiguity and ensures proper datetime alignment.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,12 @@ climpred is a Python package for verification of weather and climate forecasts a
 ## Development Commands
 
 ```bash
+# (optional) create venv with uv
+uv venv
+
+# (optional) activate venv
+source .venv/bin/activate
+
 # Install in development mode
 pip install -e ".[complete]"
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,14 @@ What's New
     mpl.rcParams["savefig.bbox"] = "tight"
 
 
+climpred v2.7.0 (unreleased)
+============================
+
+New Features
+------------
+- Added new `.agents/skills/climpred-forecast-verification/` skill for AI coding agents (e.g., Claude Code, OpenCode). Includes SKILL.md with core concepts, classes, methods, and workflows, plus reference documentation for metrics, comparisons, bias removal, and data setup. (:pr:`910`) `Aaron Spring`_
+
+
 climpred v2.6.0 (2026-02-19)
 ============================
 


### PR DESCRIPTION
## Summary

- Add new `.agents/skills/climpred-forecast-verification/` skill for AI coding agents (e.g., Claude Code, OpenCode)
- Includes SKILL.md with core concepts, classes, methods, and common workflows
- Includes reference documentation: metrics, comparisons, bias removal, and data setup guides
- Update AGENTS.md with uv venv setup instructions

## Docs
- https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf
- https://code.claude.com/docs/en/skills
- https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview

## Example Usage

This skill was tested with example usage from
- https://opncd.ai/share/b3lcO484
- https://opncd.ai/share/Af6v02HU
<img width="928" height="701" alt="image" src="https://github.com/user-attachments/assets/54f27e2a-7ce7-40f3-b555-3016556e2316" />


The skill triggers on keywords like: forecast verification, prediction skill, hindcast, climate prediction, skill score, predictability.

## Files Changed

- `.agents/skills/climpred-forecast-verification/SKILL.md` - Main skill documentation
- `.agents/skills/climpred-forecast-verification/reference/` - Reference guides
- `AGENTS.md` - Added uv venv setup instructions