### PR TITLE
Fix docs errors by removing nb_black and failing on errors

### DIFF
--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -42,7 +42,6 @@ dependencies:
   # vwmp
   - xrft
   # docs
-  - pip >=25.1
   - nb_black
   - jupyterlab
   - myst-nb

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -42,6 +42,8 @@ dependencies:
   # vwmp
   - xrft
   # docs
+  - nb_black
+  - lab_black
   - jupyterlab
   - myst-nb
   - nbstripout

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -42,8 +42,8 @@ dependencies:
   # vwmp
   - xrft
   # docs
+  - pip >=25.1
   - nb_black
-  - lab_black
   - jupyterlab
   - myst-nb
   - nbstripout

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -161,7 +161,7 @@ intersphinx_mapping = {
 # Should only be uncommented when testing page development while notebooks
 # are breaking.
 # nbsphinx_kernel_name = "climpred-docs"  # doesn't work
-nbsphinx_allow_errors = True
+nbsphinx_allow_errors = False
 nbsphinx_timeout = 600
 nbsphinx_execute = "auto"  # "never" "always"
 nb_execution_mode = "auto"


### PR DESCRIPTION
## Summary

- Remove nb_black and lab_black loading cells from all example notebooks as they cause ModuleNotFoundError in readthedocs build environment where these extensions are not available
- Changed nbsphinx_allow_errors = True to False in docs/source/conf.py to ensure notebook errors dont fail silently in docs builds

This fixes the docs errors reported in issue #909 where the verify_dim_implications.html page was showing a ModuleNotFoundError for the nb_black module.