### PR TITLE
Drop Python 3.9 support (EOL October 2025)

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu", "macos", "windows"]
-        python-version: ["3.9", "3.13"]
+        python-version: ["3.10", "3.13"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ New Features
 
 Internals/Minor Fixes
 ---------------------
+- Dropped support for Python 3.9 (EOL October 2025). Minimum supported Python is now 3.10. (:issue:`919`) `Aaron Spring`_
 - :py:meth:`.HindcastEnsemble.smooth` and :py:meth:`.PerfectModelEnsemble.smooth` propagate the ``lead`` ``units`` attribute onto the ``lead_center`` coordinate that is added during verification of temporally smoothed ensembles. `Aaron Spring`_
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,7 +25,7 @@ New Features
 
 Internals/Minor Fixes
 ---------------------
-- Dropped support for Python 3.9 (EOL October 2025). Minimum supported Python is now 3.10. (:issue:`919`) `Aaron Spring`_
+- Dropped support for Python 3.9 (EOL October 2025). Minimum supported Python is now 3.10. (:issue:`919`, :pr:`920`) `Aaron Spring`_
 - :py:meth:`.HindcastEnsemble.smooth` and :py:meth:`.PerfectModelEnsemble.smooth` propagate the ``lead`` ``units`` attribute onto the ``lead_center`` coordinate that is added during verification of temporally smoothed ensembles. `Aaron Spring`_
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ authors = [
   { name = "Aaron Spring", email = "aaron.spring@mpimet.mpg.de" },
   { name = "Riley Brady", email = "riley.brady@colorado.edu" },
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Education",
@@ -23,7 +23,6 @@ classifiers = [
   "Natural Language :: English",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -44,7 +43,7 @@ dependencies = [
 ]
 [project.optional-dependencies]
 accel = [ "bottleneck", "numba>=0.57" ]
-bias-correction = [ "bias-correction>=0.4", "xclim>=0.52", "xsdba>=0.4; python_version>='3.10'" ]
+bias-correction = [ "bias-correction>=0.4", "xclim>=0.52", "xsdba>=0.4" ]
 complete = [ "climpred[accel,bias-correction,io,relative_entropy,test,viz,vwmp]" ]
 docs = [
   "climpred[complete]",
@@ -91,7 +90,7 @@ local_scheme = "dirty-tag"
 
 [tool.black]
 line-length = 88
-target-version = [ "py39", "py310", "py311", "py312", "py313" ]
+target-version = [ "py310", "py311", "py312", "py313" ]
 
 [tool.isort]
 known_first_party = "climpred"


### PR DESCRIPTION
## Summary

Drops Python 3.9 support, which reached EOL in October 2025.

- `pyproject.toml`: bump `requires-python` to `>=3.10`, remove 3.9 classifier, remove `python_version>='3.10'` guard on `xsdba` in the `bias-correction` extra, update `black` `target-version`
- `.github/workflows/testing.yml`: replace `"3.9"` with `"3.10"` in the minimum-deps CI matrix
- `CHANGELOG.rst`: document the change

Closes #919

## Test plan

- [x] CI passes on Python 3.10 and 3.13 in the minimum-deps matrix
- [x] No remaining `python_version` guards needed for 3.9 compat

Generated with [Claude Code](https://claude.com/claude-code)