### PR TITLE
Improve error message in plot_alignment when no overlap between hindcast and verification

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,7 @@ New Features
 Internals/Minor Fixes
 ---------------------
 - :py:meth:`.HindcastEnsemble.smooth` and :py:meth:`.PerfectModelEnsemble.smooth` propagate the ``lead`` ``units`` attribute onto the ``lead_center`` coordinate that is added during verification of temporally smoothed ensembles. `Aaron Spring`_
+- :py:meth:`.HindcastEnsemble.plot_alignment` now raises a clear error message when there is no overlap between hindcast ``valid_time`` and verification ``time``, instead of a cryptic ``ValueError`` about ``CFTimeIndex`` ambiguity. (:issue:`912`, :pr:`921`) `Aaron Spring`_
 
 
 climpred v2.6.0 (2026-02-19)

--- a/src/climpred/classes.py
+++ b/src/climpred/classes.py
@@ -2140,6 +2140,12 @@ class HindcastEnsemble(PredictionEnsemble):
                 alignments_success.append(a)
             except CoordinateError as e:
                 warnings.warn(f"alignment='{a}' failed. CoordinateError: {e}")
+        if not alignment_dates:
+            raise CoordinateError(
+                "no overlap between hindcast valid_time and verification time for all "
+                "leads. Please try plot_alignment with less leads or longer "
+                "verification time."
+            )
         verif_dates_xr = (
             xr.concat(
                 alignment_dates,

--- a/src/climpred/graphics.py
+++ b/src/climpred/graphics.py
@@ -10,6 +10,7 @@ from .alignment import return_inits_and_verif_dates
 from .checks import DimensionError
 from .classes import HindcastEnsemble, PerfectModelEnsemble
 from .constants import CLIMPRED_DIMS
+from .exceptions import CoordinateError
 from .metrics import ALL_METRICS
 from .utils import get_metric_class
 
@@ -425,6 +426,13 @@ def _verif_dates_xr(hindcast, alignment, reference, date2num_units):
             else None
         ),
     )
+
+    if not inits or all(v.size == 0 for v in inits.values()):
+        raise CoordinateError(
+            "no overlap between hindcast valid_time and verification time for all "
+            "leads. Please try plot_alignment with less leads or longer verification "
+            "time."
+        )
 
     verif_dates_xr = xr.concat(
         [

--- a/src/climpred/tests/test_graphics.py
+++ b/src/climpred/tests/test_graphics.py
@@ -19,9 +19,12 @@ ITERATIONS = 300
 def cleanup_matplotlib_figures():
     """Automatically clean up matplotlib figures after each test."""
     yield
-    import matplotlib.pyplot as plt
-
-    plt.close("all")
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        pass
+    else:
+        plt.close("all")
 
 
 @requires_matplotlib

--- a/src/climpred/tests/test_graphics.py
+++ b/src/climpred/tests/test_graphics.py
@@ -7,6 +7,7 @@ import pytest
 
 from climpred import HindcastEnsemble, PerfectModelEnsemble
 from climpred.checks import DimensionError
+from climpred.exceptions import CoordinateError
 from climpred.graphics import plot_bootstrapped_skill_over_leadyear
 
 from . import requires_matplotlib, requires_nc_time_axis
@@ -136,3 +137,57 @@ def test_HindcastEnsemble_plot_alignment(hindcast_hist_obs_1d, alignment, return
             ),
             (xr.plot.facetgrid.FacetGrid, matplotlib.collections.QuadMesh),
         )
+
+
+def test_plot_alignment_no_overlap_same_inits():
+    """plot_alignment raises CoordinateError for single alignment with no overlap."""
+    import numpy as np
+    import xarray as xr
+
+    from climpred import HindcastEnsemble
+
+    inits = [1990, 1991, 1992, 1993]
+    lead = [1, 2, 3]
+    init_da = xr.DataArray(
+        np.random.rand(len(inits), len(lead)),
+        dims=["init", "lead"],
+        coords=[inits, lead],
+        name="var",
+    )
+    init_da["lead"].attrs["units"] = "years"
+    obs_da = xr.DataArray(
+        np.random.rand(3),
+        dims=["time"],
+        coords=[list(range(2000, 2003))],
+        name="var",
+    )
+    he = HindcastEnsemble(init_da.to_dataset()).add_observations(obs_da.to_dataset())
+    with pytest.raises(CoordinateError, match="no overlap between hindcast"):
+        he.plot_alignment(alignment="same_inits", return_xr=True)
+
+
+def test_plot_alignment_no_overlap_all_alignments():
+    """plot_alignment raises ValueError when all alignments fail with no overlap."""
+    import numpy as np
+    import xarray as xr
+
+    from climpred import HindcastEnsemble
+
+    inits = [1990, 1991, 1992, 1993]
+    lead = [1, 2, 3]
+    init_da = xr.DataArray(
+        np.random.rand(len(inits), len(lead)),
+        dims=["init", "lead"],
+        coords=[inits, lead],
+        name="var",
+    )
+    init_da["lead"].attrs["units"] = "years"
+    obs_da = xr.DataArray(
+        np.random.rand(3),
+        dims=["time"],
+        coords=[list(range(2000, 2003))],
+        name="var",
+    )
+    he = HindcastEnsemble(init_da.to_dataset()).add_observations(obs_da.to_dataset())
+    with pytest.raises(CoordinateError, match="no overlap between hindcast"):
+        he.plot_alignment(alignment=None, return_xr=True)


### PR DESCRIPTION
Closes #912

Adds a clear error message in `_verif_dates_xr` and `plot_alignment` when there is no overlap between hindcast `valid_time` and verification `time`, instead of a cryptic `ValueError` about `CFTimeIndex` ambiguity.

Changes:
- `src/climpred/graphics.py`: Check for empty inits in `_verif_dates_xr` and raise `CoordinateError` with helpful message
- `src/climpred/classes.py`: Fallback check in `plot_alignment` when all alignment strategies fail